### PR TITLE
Add implementation of basic logic gates

### DIFF
--- a/Projects/logic_gates/README.md
+++ b/Projects/logic_gates/README.md
@@ -1,0 +1,154 @@
+# Basic Logic Gates
+
+This example project demonstrates basic **logic gate implementations** on the **Shrike-Lite**, perfect for beginners exploring digital logic and FPGA programming.
+
+---
+
+## Folder Structure
+
+Each logic gate (AND, OR, NOT, NAND, NOR, XOR) is organized as a separate subfolder under this project:
+
+```
+logic_gates
+├── and
+├── or
+├── not
+├── nand
+├── nor
+└── xor
+```
+
+Inside each folder, you’ll find:
+
+```
+and
+├── and.ffpga
+└── ffpga
+    └── src
+        └── main.v
+```
+
+The **Verilog code** for the gate is located in `ffpga/src/main.v`.
+
+---
+
+## Hardware Setup
+
+The project uses two **interconnects** between the **RP2040 MCU** and the **FPGA** on the Shrike-Lite board:
+
+| RP2040 GPIO | FPGA Pin |
+| ----------- | -------- |
+| 14          | 18       |
+| 15          | 17       |
+
+And also uses the already available led on the board which is connected to **FPGA** on `FPGA_IO16`
+These are used as input signals for the logic gates.
+See PINOUTS [here](https://vicharak-in.github.io/shrike-lite/shrike_pinouts.html)
+
+---
+
+## Example: AND Gate
+
+**Verilog source:** `and/ffpga/src/main.v`
+
+```verilog
+(* top *) module and_gate(
+  (* iopad_external_pin *) output LED,
+  (* iopad_external_pin *) output LED_en,
+  (* iopad_external_pin *) input a,
+  (* iopad_external_pin *) input b
+);
+  
+  assign LED_en = 1'b1;
+  assign LED = a & b;
+endmodule
+```
+
+---
+
+##  Building the Project
+
+### 1. Open in Go-Configure
+
+Open the project folder in **Go-Configure** (as explained in the official documentation [here](https://vicharak-in.github.io/shrike-lite/index.html)).
+
+> Tip: To open an existing project, check the **bottom-right** corner of the Go-Configure Hub after launching.
+
+### 2. Verify Pin Connections
+
+Inside Go-Configure, use the **I/O Planner** to make sure your Verilog pins (`a`, `b`, `LED`, etc.) are mapped correctly to the **actual GPIOs** used on the RP2040-FPGA interconnect.
+
+### 3. Generate the Bitstream
+
+Hit **Generate Bitstream** at the bottom-left corner of Go-Configure.
+Once the synthesis completes, a `build` directory will appear under your gate folder.
+
+Example build output:
+
+```
+and
+├── and.ffpga
+└── ffpga
+    ├── build
+    │   ├── bitstream
+    │   │   ├── FPGA_bitstream_FLASH_MEM.bin
+    │   │   ├── FPGA_bitstream_MCU.bin
+    │   │   └── ...
+    │   ├── FPGA_bitstream.log
+    │   ├── post_synth_report.txt
+    │   ├── resource-utilization-report.log
+    │   └── ...
+    └── src
+        └── main.v
+```
+
+Your **final bitstream** file will be:
+
+```
+and/ffpga/build/FPGA_bitstream_MCU.bin
+```
+
+---
+
+## Flashing & Testing
+
+Follow the flashing instructions from the Shrike-Lite documentation [here](https://vicharak-in.github.io/shrike-lite/getting_started.html) to upload the generated `.bin` file to your FPGA.
+
+> Tip: For faster way to access your shrike according to me you maybe interested in CLI based flashing and running micropython, [here is the guide for the same](https://vicharak-in.github.io/shrike-lite/shrike_cli_guide.html)
+
+Then, on the RP2040 side, toggle the input GPIOs via **MicroPython**:
+
+**Both inputs HIGH:**
+
+```python
+import machine
+a = machine.Pin(15, machine.Pin.OUT)
+b = machine.Pin(14, machine.Pin.OUT)
+a.value(1)
+b.value(1)
+```
+
+**Both inputs LOW:**
+
+```python
+import machine
+a = machine.Pin(15, machine.Pin.OUT)
+b = machine.Pin(14, machine.Pin.OUT)
+a.value(0)
+b.value(0)
+```
+
+The **LED output** on the FPGA will light up according to your logic gate behavior — in this case, only when both `a` and `b` are high.
+
+---
+
+## Available Gates
+
+| Gate | Folder  | Description           |
+| ---- | ------- | --------------------- |
+| AND  | `and/`  | Logical AND operation |
+| OR   | `or/`   | Logical OR operation  |
+| NOT  | `not/`  | Logical inversion     |
+| NAND | `nand/` | Inverted AND          |
+| NOR  | `nor/`  | Inverted OR           |
+| XOR  | `xor/`  | Exclusive OR          |

--- a/Projects/logic_gates/and/and.ffpga
+++ b/Projects/logic_gates/and/and.ffpga
@@ -1,0 +1,846 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GPDProject version="37" oldestCompatibleVersion="32" GPDVersion="6.48.001" lastChange="11 Nov 2025 16:12:36" projectChecksumState="1" projectChecksum="1891754f">
+    <generalProjectSettings/>
+    <chip family="04" type="06" friendlyName="FFPGA" partNumber="67" package="26">
+        <nvmData registerLenght="480">0 0 0 28 0 0 0 0 A5 A5 A5 A5 0 0 0 0 0 0 0 0 5A 5A 5A 5A 0 0 0 0 22 22 22 22 22 22 22 22 22 22 0 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</nvmData>
+        <checksum crc32="0x451C1D42" version="2"/>
+        <VDDItem id="0">
+            <item id="0" caption="VDD (PIN 22)">
+                <graphics pos="(1350.00,143.10)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <VDDItem id="1">
+            <item id="1" caption="VDDIO (PIN 21)">
+                <graphics pos="(1350.00,226.67)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <item id="2" caption="GND (PIN 12)">
+            <graphics pos="(1350.00,298.48)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="3" caption="FPGA">
+            <graphics pos="(0.00,0.00)" angle="0" flipping="0" hidden="0" tOrigin="(640.00,442.50)"/>
+        </item>
+        <item id="4" caption="GPIO0 (PIN 13)">
+            <graphics pos="(35.00,592.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="5" caption="GPIO1 (PIN 14)">
+            <graphics pos="(150.00,542.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="6" caption="GPIO2 (PIN 15)">
+            <graphics pos="(35.00,493.59)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="7" caption="GPIO3 (PIN 16)">
+            <graphics pos="(150.00,444.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="8" caption="GPIO4 (PIN 17)">
+            <graphics pos="(35.00,394.74)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="9" caption="GPIO5 (PIN 18)">
+            <graphics pos="(35.00,197.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="10" caption="GPIO6 (PIN 19)">
+            <graphics pos="(150.00,148.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="11" caption="GPIO7 (PIN 20)">
+            <graphics pos="(35.00,98.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="12" caption="GPIO8 (PIN 23)">
+            <graphics pos="(1094.00,49.99)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="13" caption="GPIO9 (PIN 24)">
+            <graphics pos="(1200.00,102.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="14" caption="GPIO10 (PIN 1)">
+            <graphics pos="(1094.00,154.03)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="15" caption="GPIO11 (PIN 2)">
+            <graphics pos="(1200.00,206.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="16" caption="GPIO12 (PIN 3)">
+            <graphics pos="(1094.00,258.20)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="17" caption="GPIO13 (PIN 4)">
+            <graphics pos="(1200.00,310.28)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="18" caption="GPIO14 (PIN 5)">
+            <graphics pos="(1094.00,397.09)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="19" caption="GPIO15 (PIN 6)">
+            <graphics pos="(1200.00,449.75)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="20" caption="GPIO18 (PIN 9/GrP0)">
+            <graphics pos="(1094.00,604.84)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="21" caption="GPIO17 (PIN 8/GrP1)">
+            <graphics pos="(1200.00,553.34)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="22" caption="GPIO16 (PIN 7/GrP2)">
+            <graphics pos="(1094.00,501.25)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="23" caption="nRST (PIN 11)">
+            <graphics pos="(1094.00,356.17)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="24" caption="nSLEEP (PIN 10)">
+            <graphics pos="(1200.00,374.22)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="25" caption="OSC">
+            <graphics pos="(150.00,64.53)" angle="0" flipping="0" hidden="0" tOrigin="(25.00,10.00)"/>
+        </item>
+        <item id="26" caption="Phase-Locked Loop">
+            <graphics pos="(149.73,246.87)" angle="180" flipping="0" hidden="0" tOrigin="(25.00,70.00)"/>
+        </item>
+        <item id="27" caption="BRAM">
+            <graphics pos="(616.77,701.83)" angle="90" flipping="0" hidden="0" tOrigin="(25.00,100.00)"/>
+        </item>
+        <item id="28" caption="FPGA Core">
+            <graphics pos="(340.90,49.43)" angle="0" flipping="0" hidden="0" tOrigin="(300.00,300.00)"/>
+        </item>
+        <wire output="79" input="65" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (236.00,80.00); (236.00,250.00); (220.00,250.00)</points>
+        </wire>
+        <wire output="2" input="66" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (226.00,510.00); (226.00,383.00); (220.00,383.00)</points>
+        </wire>
+        <wire output="83" input="85" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="0" wireText="NET0" wireState="0">
+            <points>(129.00,344.00); (116.00,344.00); (116.00,392.00); (308.00,392.00); (308.00,383.00); (320.00,383.00)</points>
+        </wire>
+        <wire output="84" input="86" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="1" wireText="NET1" wireState="0">
+            <points>(711.00,669.00); (711.00,756.00)</points>
+        </wire>
+        <wire output="85" input="87" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="2" wireText="NET2" wireState="0">
+            <points>(726.00,669.00); (726.00,756.00)</points>
+        </wire>
+        <wire output="86" input="88" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="3" wireText="NET3" wireState="0">
+            <points>(220.00,70.00); (320.00,70.00)</points>
+        </wire>
+        <wire output="79" input="38" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (314.00,80.00); (314.00,87.00); (320.00,87.00)</points>
+        </wire>
+        <wire output="39" input="63" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="5" wireText="NET5" wireState="0">
+            <points>(320.00,54.00); (116.00,54.00); (116.00,75.00); (129.00,75.00)</points>
+        </wire>
+        <wire output="20" input="62" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="6" wireText="NET6" wireState="0">
+            <points>(1177.00,384.00); (967.00,384.00); (967.00,385.00); (961.00,385.00)</points>
+        </wire>
+        <wire output="19" input="61" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="7" wireText="NET7" wireState="0">
+            <points>(1071.00,366.00); (967.00,366.00); (967.00,367.00); (961.00,367.00)</points>
+        </wire>
+        <wire output="82" input="41" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="8" wireText="NET8" wireState="0">
+            <points>(642.00,847.00); (642.00,853.00); (308.00,853.00); (308.00,645.00); (320.00,645.00)</points>
+        </wire>
+        <wire output="21" input="75" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="9" wireText="NET9" wireState="0">
+            <points>(557.00,669.00); (557.00,756.00)</points>
+        </wire>
+        <wire output="25" input="76" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="10" wireText="NET10" wireState="0">
+            <points>(618.00,669.00); (618.00,756.00)</points>
+        </wire>
+        <wire output="22" input="77" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="11" wireText="NET11" wireState="0">
+            <points>(573.00,669.00); (573.00,756.00)</points>
+        </wire>
+        <wire output="23" input="78" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="12" wireText="NET12" wireState="0">
+            <points>(588.00,669.00); (588.00,756.00)</points>
+        </wire>
+        <wire output="26" input="79" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="13" wireText="NET13" wireState="0">
+            <points>(634.00,669.00); (634.00,756.00)</points>
+        </wire>
+        <wire output="27" input="80" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="14" wireText="NET14" wireState="0">
+            <points>(649.00,669.00); (649.00,756.00)</points>
+        </wire>
+        <wire output="28" input="81" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="15" wireText="NET15" wireState="0">
+            <points>(664.00,669.00); (664.00,756.00)</points>
+        </wire>
+        <wire output="24" input="82" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="16" wireText="NET16" wireState="0">
+            <points>(603.00,669.00); (603.00,756.00)</points>
+        </wire>
+        <wire output="29" input="83" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="17" wireText="NET17" wireState="0">
+            <points>(680.00,669.00); (680.00,756.00)</points>
+        </wire>
+        <wire output="30" input="84" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="18" wireText="NET18" wireState="0">
+            <points>(695.00,669.00); (695.00,756.00)</points>
+        </wire>
+        <wire output="80" input="39" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="20" wireText="NET20" wireState="0">
+            <points>(129.00,289.00); (116.00,289.00); (116.00,240.00); (308.00,240.00); (308.00,251.00); (320.00,251.00)</points>
+        </wire>
+        <wire output="34" input="67" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="21" wireText="NET21" wireState="0">
+            <points>(320.00,333.00); (220.00,333.00)</points>
+        </wire>
+        <wire output="38" input="68" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="22" wireText="NET22" wireState="0">
+            <points>(320.00,267.00); (220.00,267.00)</points>
+        </wire>
+        <wire output="37" input="69" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="23" wireText="NET23" wireState="0">
+            <points>(320.00,284.00); (220.00,284.00)</points>
+        </wire>
+        <wire output="36" input="70" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="24" wireText="NET24" wireState="0">
+            <points>(320.00,300.00); (220.00,300.00)</points>
+        </wire>
+        <wire output="35" input="71" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="25" wireText="NET25" wireState="0">
+            <points>(320.00,317.00); (220.00,317.00)</points>
+        </wire>
+        <wire output="33" input="72" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="26" wireText="NET26" wireState="0">
+            <points>(320.00,350.00); (220.00,350.00)</points>
+        </wire>
+        <wire output="32" input="73" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="27" wireText="NET27" wireState="0">
+            <points>(320.00,366.00); (220.00,366.00)</points>
+        </wire>
+        <wire output="41" input="0" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="28" wireText="NET28" wireState="0">
+            <points>(320.00,597.00); (97.00,597.00)</points>
+        </wire>
+        <wire output="42" input="1" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="29" wireText="NET29" wireState="0">
+            <points>(320.00,547.00); (212.00,547.00)</points>
+        </wire>
+        <wire output="43" input="2" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="30" wireText="NET30" wireState="0">
+            <points>(320.00,498.00); (97.00,498.00)</points>
+        </wire>
+        <wire output="44" input="3" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="31" wireText="NET31" wireState="0">
+            <points>(320.00,449.00); (212.00,449.00)</points>
+        </wire>
+        <wire output="45" input="4" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="32" wireText="NET32" wireState="0">
+            <points>(320.00,399.00); (97.00,399.00)</points>
+        </wire>
+        <wire output="46" input="5" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="33" wireText="NET33" wireState="0">
+            <points>(320.00,202.00); (97.00,202.00)</points>
+        </wire>
+        <wire output="47" input="6" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="34" wireText="NET34" wireState="0">
+            <points>(320.00,153.00); (212.00,153.00)</points>
+        </wire>
+        <wire output="48" input="7" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="35" wireText="NET35" wireState="0">
+            <points>(320.00,103.00); (97.00,103.00)</points>
+        </wire>
+        <wire output="49" input="8" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="36" wireText="NET36" wireState="0">
+            <points>(961.00,55.00); (1071.00,55.00)</points>
+        </wire>
+        <wire output="50" input="9" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="37" wireText="NET37" wireState="0">
+            <points>(961.00,107.00); (1177.00,107.00)</points>
+        </wire>
+        <wire output="51" input="10" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="38" wireText="NET38" wireState="0">
+            <points>(961.00,159.00); (1071.00,159.00)</points>
+        </wire>
+        <wire output="52" input="11" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="39" wireText="NET39" wireState="0">
+            <points>(961.00,211.00); (1177.00,211.00)</points>
+        </wire>
+        <wire output="53" input="12" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="40" wireText="NET40" wireState="0">
+            <points>(961.00,263.00); (1071.00,263.00)</points>
+        </wire>
+        <wire output="54" input="13" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="41" wireText="NET41" wireState="0">
+            <points>(961.00,315.00); (1177.00,315.00)</points>
+        </wire>
+        <wire output="55" input="14" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="42" wireText="NET42" wireState="0">
+            <points>(961.00,402.00); (1071.00,402.00)</points>
+        </wire>
+        <wire output="56" input="15" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="43" wireText="NET43" wireState="0">
+            <points>(961.00,454.00); (1177.00,454.00)</points>
+        </wire>
+        <wire output="57" input="16" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="44" wireText="NET44" wireState="0">
+            <points>(961.00,610.00); (1071.00,610.00)</points>
+        </wire>
+        <wire output="58" input="17" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="45" wireText="NET45" wireState="0">
+            <points>(961.00,558.00); (1177.00,558.00)</points>
+        </wire>
+        <wire output="59" input="18" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="46" wireText="NET46" wireState="0">
+            <points>(961.00,506.00); (1071.00,506.00)</points>
+        </wire>
+        <wire output="60" input="19" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="47" wireText="NET47" wireState="0">
+            <points>(320.00,630.00); (108.00,630.00); (108.00,648.00); (54.00,648.00); (54.00,633.00)</points>
+        </wire>
+        <wire output="61" input="20" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="48" wireText="NET48" wireState="0">
+            <points>(320.00,580.00); (220.00,580.00); (220.00,588.00); (169.00,588.00); (169.00,582.00)</points>
+        </wire>
+        <wire output="62" input="21" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="49" wireText="NET49" wireState="0">
+            <points>(320.00,531.00); (108.00,531.00); (108.00,552.00); (54.00,552.00); (54.00,534.00)</points>
+        </wire>
+        <wire output="63" input="22" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="50" wireText="NET50" wireState="0">
+            <points>(320.00,482.00); (220.00,482.00); (220.00,490.00); (169.00,490.00); (169.00,484.00)</points>
+        </wire>
+        <wire output="64" input="23" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="51" wireText="NET51" wireState="0">
+            <points>(320.00,432.00); (108.00,432.00); (108.00,448.00); (54.00,448.00); (54.00,435.00)</points>
+        </wire>
+        <wire output="65" input="24" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="52" wireText="NET52" wireState="0">
+            <points>(320.00,235.00); (108.00,235.00); (108.00,248.00); (54.00,248.00); (54.00,237.00)</points>
+        </wire>
+        <wire output="66" input="25" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="53" wireText="NET53" wireState="0">
+            <points>(320.00,185.00); (220.00,185.00); (220.00,194.00); (169.00,194.00); (169.00,188.00)</points>
+        </wire>
+        <wire output="67" input="26" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="54" wireText="NET54" wireState="0">
+            <points>(320.00,136.00); (108.00,136.00); (108.00,152.00); (54.00,152.00); (54.00,139.00)</points>
+        </wire>
+        <wire output="68" input="27" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="55" wireText="NET55" wireState="0">
+            <points>(961.00,90.00); (1060.00,90.00); (1060.00,96.00); (1113.00,96.00); (1113.00,90.00)</points>
+        </wire>
+        <wire output="69" input="28" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="56" wireText="NET56" wireState="0">
+            <points>(961.00,142.00); (1172.00,142.00); (1172.00,160.00); (1219.00,160.00); (1219.00,142.00)</points>
+        </wire>
+        <wire output="70" input="29" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="57" wireText="NET57" wireState="0">
+            <points>(961.00,194.00); (1060.00,194.00); (1060.00,200.00); (1113.00,200.00); (1113.00,194.00)</points>
+        </wire>
+        <wire output="71" input="30" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="58" wireText="NET58" wireState="0">
+            <points>(961.00,246.00); (1172.00,246.00); (1172.00,264.00); (1219.00,264.00); (1219.00,246.00)</points>
+        </wire>
+        <wire output="72" input="31" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="59" wireText="NET59" wireState="0">
+            <points>(961.00,298.00); (1060.00,298.00); (1060.00,304.00); (1113.00,304.00); (1113.00,298.00)</points>
+        </wire>
+        <wire output="73" input="32" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="60" wireText="NET60" wireState="0">
+            <points>(961.00,350.00); (1172.00,350.00); (1172.00,356.00); (1219.00,356.00); (1219.00,350.00)</points>
+        </wire>
+        <wire output="74" input="33" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="61" wireText="NET61" wireState="0">
+            <points>(961.00,437.00); (1060.00,437.00); (1060.00,443.00); (1113.00,443.00); (1113.00,437.00)</points>
+        </wire>
+        <wire output="75" input="34" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="62" wireText="NET62" wireState="0">
+            <points>(961.00,489.00); (1172.00,489.00); (1172.00,504.00); (1219.00,504.00); (1219.00,490.00)</points>
+        </wire>
+        <wire output="76" input="35" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="63" wireText="NET63" wireState="0">
+            <points>(961.00,645.00); (1060.00,645.00); (1060.00,664.00); (1113.00,664.00); (1113.00,645.00)</points>
+        </wire>
+        <wire output="77" input="36" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="64" wireText="NET64" wireState="0">
+            <points>(961.00,593.00); (1172.00,593.00); (1172.00,608.00); (1219.00,608.00); (1219.00,593.00)</points>
+        </wire>
+        <wire output="78" input="37" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="65" wireText="NET65" wireState="0">
+            <points>(961.00,541.00); (1060.00,541.00); (1060.00,547.00); (1113.00,547.00); (1113.00,541.00)</points>
+        </wire>
+        <wire output="0" input="42" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="66" wireText="NET66" wireState="0">
+            <points>(97.00,609.00); (314.00,609.00); (314.00,613.00); (320.00,613.00)</points>
+        </wire>
+        <wire output="1" input="43" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="67" wireText="NET67" wireState="0">
+            <points>(212.00,558.00); (314.00,558.00); (314.00,564.00); (320.00,564.00)</points>
+        </wire>
+        <wire output="2" input="44" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (314.00,510.00); (314.00,514.00); (320.00,514.00)</points>
+        </wire>
+        <wire output="3" input="45" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="68" wireText="NET68" wireState="0">
+            <points>(212.00,460.00); (314.00,460.00); (314.00,465.00); (320.00,465.00)</points>
+        </wire>
+        <wire output="4" input="46" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="69" wireText="NET69" wireState="0">
+            <points>(97.00,411.00); (314.00,411.00); (314.00,416.00); (320.00,416.00)</points>
+        </wire>
+        <wire output="5" input="47" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="70" wireText="NET70" wireState="0">
+            <points>(97.00,213.00); (314.00,213.00); (314.00,218.00); (320.00,218.00)</points>
+        </wire>
+        <wire output="6" input="48" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="71" wireText="NET71" wireState="0">
+            <points>(212.00,164.00); (314.00,164.00); (314.00,169.00); (320.00,169.00)</points>
+        </wire>
+        <wire output="7" input="49" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="72" wireText="NET72" wireState="0">
+            <points>(97.00,115.00); (314.00,115.00); (314.00,120.00); (320.00,120.00)</points>
+        </wire>
+        <wire output="8" input="50" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="73" wireText="NET73" wireState="0">
+            <points>(1071.00,66.00); (967.00,66.00); (967.00,72.00); (961.00,72.00)</points>
+        </wire>
+        <wire output="9" input="51" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="74" wireText="NET74" wireState="0">
+            <points>(1177.00,118.00); (967.00,118.00); (967.00,124.00); (961.00,124.00)</points>
+        </wire>
+        <wire output="10" input="52" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="75" wireText="NET75" wireState="0">
+            <points>(1071.00,170.00); (967.00,170.00); (967.00,176.00); (961.00,176.00)</points>
+        </wire>
+        <wire output="11" input="53" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="76" wireText="NET76" wireState="0">
+            <points>(1177.00,222.00); (967.00,222.00); (967.00,228.00); (961.00,228.00)</points>
+        </wire>
+        <wire output="12" input="54" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="77" wireText="NET77" wireState="0">
+            <points>(1071.00,275.00); (967.00,275.00); (967.00,280.00); (961.00,280.00)</points>
+        </wire>
+        <wire output="13" input="55" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="78" wireText="NET78" wireState="0">
+            <points>(1177.00,327.00); (967.00,327.00); (967.00,333.00); (961.00,333.00)</points>
+        </wire>
+        <wire output="14" input="56" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="79" wireText="NET79" wireState="0">
+            <points>(1071.00,413.00); (967.00,413.00); (967.00,419.00); (961.00,419.00)</points>
+        </wire>
+        <wire output="15" input="57" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="80" wireText="NET80" wireState="0">
+            <points>(1177.00,466.00); (967.00,466.00); (967.00,471.00); (961.00,471.00)</points>
+        </wire>
+        <wire output="16" input="58" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="81" wireText="NET81" wireState="0">
+            <points>(1071.00,621.00); (967.00,621.00); (967.00,628.00); (961.00,628.00)</points>
+        </wire>
+        <wire output="17" input="59" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="82" wireText="NET82" wireState="0">
+            <points>(1177.00,570.00); (967.00,570.00); (967.00,576.00); (961.00,576.00)</points>
+        </wire>
+        <wire output="18" input="60" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="83" wireText="NET83" wireState="0">
+            <points>(1071.00,518.00); (967.00,518.00); (967.00,524.00); (961.00,524.00)</points>
+        </wire>
+    </chip>
+    <emulatorConfiguration version="4" oldestCompatibleVersion="4">
+        <settings>
+            <autoApply value="0"/>
+            <platformSelector id="-1"/>
+        </settings>
+        <platform id="0" friendlyName="GreenPAK DIP Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="1" friendlyName="GreenPAK Advanced Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="2" friendlyName="GreenPAK Pro Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="4" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="5" friendlyName="GreenPAK Advanced Development Platform w/ Logic Level Adapter #1">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="6" friendlyName="ForgeFPGA Deluxe Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="7" friendlyName="ForgeFPGA Evaluation Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="8" friendlyName="SLG51000 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="9" friendlyName="SLG51001 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="10" friendlyName="SLG51002 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="11" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="12" friendlyName="GreenPAK Lite Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="13" friendlyName="HVPAK Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="14" friendlyName="SLG47105V Training Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="15" friendlyName="Power GreenPAK Development Motherboard">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="16" friendlyName="ForgeFPGA Deluxe Development Platform Rev. 2.0">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="17" friendlyName="HVPAK SLG47125 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+    </emulatorConfiguration>
+    <fpga-data>
+        <!--Fpga project data-->
+        <project-data-version>5</project-data-version>
+        <oldestCompatibleVersion>3</oldestCompatibleVersion>
+        <settings>
+            <generateBitstream>
+                <MAX_CPU>16</MAX_CPU>
+                <additionalArguments></additionalArguments>
+                <clockConcurrentOptimization>true</clockConcurrentOptimization>
+                <highDensityIOPacking>false</highDensityIOPacking>
+                <highDensityPackingLogic>true</highDensityPackingLogic>
+                <maximumRoutingIterations>300</maximumRoutingIterations>
+                <placeAndTrialRoute>false</placeAndTrialRoute>
+                <placeAndTrialRouteIterationCount>20</placeAndTrialRouteIterationCount>
+            </generateBitstream>
+            <simulation>
+                <wavedumpOutputFormat>1</wavedumpOutputFormat>
+            </simulation>
+            <synthesize>
+                <additionalArguments></additionalArguments>
+                <flatten>true</flatten>
+                <keep>false</keep>
+                <noDSP>true</noDSP>
+                <useABC9>true</useABC9>
+            </synthesize>
+        </settings>
+        <openedTabs>
+            <openedTab>main.v</openedTab>
+            <openedTab>I/O Planner</openedTab>
+        </openedTabs>
+        <pipelineStagesStates>
+            <pipelineStageState>
+                <pipelineStage>0</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+            <pipelineStageState>
+                <pipelineStage>1</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+        </pipelineStagesStates>
+        <modules>
+            <scr>
+                <module filename="main.v"/>
+            </scr>
+            <lib/>
+            <sim/>
+            <netlists/>
+            <timing-constraints/>
+        </modules>
+        <io-spec-tool>
+            <records filter="16">
+                <record id="IOB_t[0:0]_xy[31:4]_in0">
+                    <port-name>b</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:5]_in0">
+                    <port-name>a</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:6]_out0">
+                    <port-name>LED</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:6]_out1">
+                    <port-name>LED_en</port-name>
+                </record>
+            </records>
+        </io-spec-tool>
+        <macrocell-mode-data>
+            <scene-data>
+                <scene-width>32767</scene-width>
+                <scene-height>32767</scene-height>
+                <scene-snapToGrid>1</scene-snapToGrid>
+            </scene-data>
+            <macrocells-data>
+                <macrocell>
+                    <macrocell-id>18</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input18</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>-240</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>19</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>20</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input20</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>21</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>22</macrocell-id>
+                    <macrocell-type>4</macrocell-type>
+                    <macrocell-title>NOT Gate</macrocell-title>
+                    <macrocell-name>not22</macrocell-name>
+                    <macrocell-posx>-100</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>23</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>24</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>25</macrocell-id>
+                    <macrocell-type>8</macrocell-type>
+                    <macrocell-title>NAND Gate</macrocell-title>
+                    <macrocell-name>nand25</macrocell-name>
+                    <macrocell-posx>240</macrocell-posx>
+                    <macrocell-posy>-200</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>26</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                        <port>
+                            <port-id>27</port-id>
+                            <port-index>1</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>28</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>29</macrocell-id>
+                    <macrocell-type>3</macrocell-type>
+                    <macrocell-title>OUT</macrocell-title>
+                    <macrocell-name>output29</macrocell-name>
+                    <macrocell-posx>640</macrocell-posx>
+                    <macrocell-posy>-140</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>30</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports/>
+                </macrocell>
+            </macrocells-data>
+            <wires-data>
+                <wire>
+                    <wire-id>31</wire-id>
+                    <wire-start-port-id>19</wire-start-port-id>
+                    <wire-end-port-id>26</wire-end-port-id>
+                    <wire-name>wire31</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>32</wire-id>
+                    <wire-start-port-id>21</wire-start-port-id>
+                    <wire-end-port-id>23</wire-end-port-id>
+                    <wire-name>wire32</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>33</wire-id>
+                    <wire-start-port-id>24</wire-start-port-id>
+                    <wire-end-port-id>27</wire-end-port-id>
+                    <wire-name>wire33</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>34</wire-id>
+                    <wire-start-port-id>28</wire-start-port-id>
+                    <wire-end-port-id>30</wire-end-port-id>
+                    <wire-name>wire34</wire-name>
+                </wire>
+            </wires-data>
+        </macrocell-mode-data>
+        <!--Fpga project data END-->
+    </fpga-data>
+    <projectData>
+        <specs>
+            <lastModify lastModifyValue="11.11.2025 10:16:33"/>
+            <vddSpecs vddMin="1.15" vddTyp="1.15" vddMax="1.15"/>
+            <vdd2Specs vdd2Min="1.71" vdd2Typ="3.3" vdd2Max="3.3"/>
+            <tempSpecs tempMin="-40" tempTyp="25" tempMax="85"/>
+        </specs>
+        <projectDataFields>
+            <textLineDataField name="Customer Name" id="2" text=""/>
+            <textLineDataField name="Customer Project Name" id="3" text=""/>
+            <textLineDataField name="Customer Project Number" id="4" text=""/>
+            <textLineDataField name="Customer Version Number" id="5" text=""/>
+            <multiTextLineDataField>
+                <textLineDataField name="Notes" id="6" text=""/>
+            </multiTextLineDataField>
+        </projectDataFields>
+    </projectData>
+    <i2cTool>
+        <i2cDebugger version="1"/>
+        <i2cStepper version="1" rowCount="0"/>
+        <i2cRegsTable version="1" tabCount="0"/>
+    </i2cTool>
+<logicAnalyzer>
+    <metadata>
+        <autosavePreset>-1</autosavePreset>
+        <currentPreset>-1</currentPreset>
+        <version>3</version>
+    </metadata>
+    <presetList/>
+</logicAnalyzer>
+
+</GPDProject>

--- a/Projects/logic_gates/and/ffpga/src/main.v
+++ b/Projects/logic_gates/and/ffpga/src/main.v
@@ -1,0 +1,40 @@
+//-----------------------------------------------------------------------------
+// Company:         Vicharak Computers PVT LTD
+// Engineer:        Shashank Bhosagi <shashankbhosagi0121@gmail.com>
+// 
+// Create Date:     NOV 11, 2025
+// Design Name:     Basic Logic Gates
+// Module Name:     and_gate
+// Project:         Shrike-Lite Examples
+// Target Device:   Shrike-Lite (RP2040 + Renesas FPGA (SLG47910V))
+// Tool Versions:   Go Configure Software Hub v.6.48
+// 
+// Description: 
+//    Simple 2-input AND gate implementation for beginners exploring
+//    FPGA design using Verilog on the Shrike-Lite platform.
+// Dependencies: 
+// None
+//
+// Version:
+//    1.0 - 11/11/2025 - Initial release
+// 
+// Additional Comments: 
+//    This project is part of https://github.com/vicharak-in/shrike-lite.
+//    All logic gate examples (AND, OR, NOT, NAND, NOR, XOR) are
+//    available under the same structure. 
+// License: 
+//    Open Source — MIT License
+//    Copyright © 2025 Vicharak Computers Pvt. Ltd
+//-----------------------------------------------------------------------------
+
+(* top *) module and_gate(
+  (* iopad_external_pin *) output LED,
+  (* iopad_external_pin *) output LED_en,
+  (* iopad_external_pin *) input a,  
+  (* iopad_external_pin *) input b,
+  );
+  
+  assign LED_en = 1'b1;
+  assign LED = a & b;
+  
+endmodule

--- a/Projects/logic_gates/nand/ffpga/src/main.v
+++ b/Projects/logic_gates/nand/ffpga/src/main.v
@@ -1,0 +1,44 @@
+//-----------------------------------------------------------------------------
+// Company:         Vicharak Computers PVT LTD
+// Engineer:        Shashank Bhosagi <shashankbhosagi0121@gmail.com>
+// 
+// Create Date:     NOV 11, 2025
+// Design Name:     Basic Logic Gates
+// Module Name:     nand_gate
+// Project:         Shrike-Lite Examples
+// Target Device:   Shrike-Lite (RP2040 + Renesas FPGA (SLG47910V))
+// Tool Versions:   Go Configure Software Hub v.6.48
+// 
+// Description: 
+//    Simple 2-input NAND gate implementation for beginners exploring
+//    FPGA design using Verilog on the Shrike-Lite.
+// Dependencies: 
+// None
+//
+// Version:
+//    1.0 - 11/11/2025 - Initial release
+// 
+// Additional Comments: 
+//    This project is part of https://github.com/vicharak-in/shrike-lite.
+//    All logic gate examples (AND, OR, NOT, NAND, NOR, XOR) are
+//    available under the same structure. 
+// License: 
+//    Open Source — MIT License
+//    Copyright © 2025 Vicharak Computers Pvt. Ltd
+//-----------------------------------------------------------------------------
+
+
+(* top *) module nand_gate(
+  (* iopad_external_pin *) output LED,
+  (* iopad_external_pin *) output LED_en,
+  (* iopad_external_pin *) input a,  
+  (* iopad_external_pin *) input b,
+  );
+  
+  assign LED_en = 1'b1;
+  wire and_output;
+  
+  assign and_output = a & b;
+  assign LED = ~(and_output);
+  
+endmodule

--- a/Projects/logic_gates/nand/nand.ffpga
+++ b/Projects/logic_gates/nand/nand.ffpga
@@ -1,0 +1,846 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GPDProject version="37" oldestCompatibleVersion="32" GPDVersion="6.48.001" lastChange="11 Nov 2025 17:22:44" projectChecksumState="1" projectChecksum="3ef8957a">
+    <generalProjectSettings/>
+    <chip family="04" type="06" friendlyName="FFPGA" partNumber="67" package="26">
+        <nvmData registerLenght="480">0 0 0 28 0 0 0 0 A5 A5 A5 A5 0 0 0 0 0 0 0 0 5A 5A 5A 5A 0 0 0 0 22 22 22 22 22 22 22 22 22 22 0 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</nvmData>
+        <checksum crc32="0x451C1D42" version="2"/>
+        <VDDItem id="0">
+            <item id="0" caption="VDD (PIN 22)">
+                <graphics pos="(1350.00,143.10)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <VDDItem id="1">
+            <item id="1" caption="VDDIO (PIN 21)">
+                <graphics pos="(1350.00,226.67)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <item id="2" caption="GND (PIN 12)">
+            <graphics pos="(1350.00,298.48)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="3" caption="FPGA">
+            <graphics pos="(0.00,0.00)" angle="0" flipping="0" hidden="0" tOrigin="(640.00,442.50)"/>
+        </item>
+        <item id="4" caption="GPIO0 (PIN 13)">
+            <graphics pos="(35.00,592.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="5" caption="GPIO1 (PIN 14)">
+            <graphics pos="(150.00,542.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="6" caption="GPIO2 (PIN 15)">
+            <graphics pos="(35.00,493.59)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="7" caption="GPIO3 (PIN 16)">
+            <graphics pos="(150.00,444.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="8" caption="GPIO4 (PIN 17)">
+            <graphics pos="(35.00,394.74)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="9" caption="GPIO5 (PIN 18)">
+            <graphics pos="(35.00,197.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="10" caption="GPIO6 (PIN 19)">
+            <graphics pos="(150.00,148.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="11" caption="GPIO7 (PIN 20)">
+            <graphics pos="(35.00,98.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="12" caption="GPIO8 (PIN 23)">
+            <graphics pos="(1094.00,49.99)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="13" caption="GPIO9 (PIN 24)">
+            <graphics pos="(1200.00,102.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="14" caption="GPIO10 (PIN 1)">
+            <graphics pos="(1094.00,154.03)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="15" caption="GPIO11 (PIN 2)">
+            <graphics pos="(1200.00,206.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="16" caption="GPIO12 (PIN 3)">
+            <graphics pos="(1094.00,258.20)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="17" caption="GPIO13 (PIN 4)">
+            <graphics pos="(1200.00,310.28)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="18" caption="GPIO14 (PIN 5)">
+            <graphics pos="(1094.00,397.09)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="19" caption="GPIO15 (PIN 6)">
+            <graphics pos="(1200.00,449.75)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="20" caption="GPIO18 (PIN 9/GrP0)">
+            <graphics pos="(1094.00,604.84)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="21" caption="GPIO17 (PIN 8/GrP1)">
+            <graphics pos="(1200.00,553.34)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="22" caption="GPIO16 (PIN 7/GrP2)">
+            <graphics pos="(1094.00,501.25)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="23" caption="nRST (PIN 11)">
+            <graphics pos="(1094.00,356.17)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="24" caption="nSLEEP (PIN 10)">
+            <graphics pos="(1200.00,374.22)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="25" caption="OSC">
+            <graphics pos="(150.00,64.53)" angle="0" flipping="0" hidden="0" tOrigin="(25.00,10.00)"/>
+        </item>
+        <item id="26" caption="Phase-Locked Loop">
+            <graphics pos="(149.73,246.87)" angle="180" flipping="0" hidden="0" tOrigin="(25.00,70.00)"/>
+        </item>
+        <item id="27" caption="BRAM">
+            <graphics pos="(616.77,701.83)" angle="90" flipping="0" hidden="0" tOrigin="(25.00,100.00)"/>
+        </item>
+        <item id="28" caption="FPGA Core">
+            <graphics pos="(340.90,49.43)" angle="0" flipping="0" hidden="0" tOrigin="(300.00,300.00)"/>
+        </item>
+        <wire output="79" input="65" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (236.00,80.00); (236.00,250.00); (220.00,250.00)</points>
+        </wire>
+        <wire output="2" input="66" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (226.00,510.00); (226.00,383.00); (220.00,383.00)</points>
+        </wire>
+        <wire output="83" input="85" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="0" wireText="NET0" wireState="0">
+            <points>(129.00,344.00); (116.00,344.00); (116.00,392.00); (308.00,392.00); (308.00,383.00); (320.00,383.00)</points>
+        </wire>
+        <wire output="84" input="86" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="1" wireText="NET1" wireState="0">
+            <points>(711.00,669.00); (711.00,756.00)</points>
+        </wire>
+        <wire output="85" input="87" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="2" wireText="NET2" wireState="0">
+            <points>(726.00,669.00); (726.00,756.00)</points>
+        </wire>
+        <wire output="86" input="88" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="3" wireText="NET3" wireState="0">
+            <points>(220.00,70.00); (320.00,70.00)</points>
+        </wire>
+        <wire output="79" input="38" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (314.00,80.00); (314.00,87.00); (320.00,87.00)</points>
+        </wire>
+        <wire output="39" input="63" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="5" wireText="NET5" wireState="0">
+            <points>(320.00,54.00); (116.00,54.00); (116.00,75.00); (129.00,75.00)</points>
+        </wire>
+        <wire output="20" input="62" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="6" wireText="NET6" wireState="0">
+            <points>(1177.00,384.00); (967.00,384.00); (967.00,385.00); (961.00,385.00)</points>
+        </wire>
+        <wire output="19" input="61" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="7" wireText="NET7" wireState="0">
+            <points>(1071.00,366.00); (967.00,366.00); (967.00,367.00); (961.00,367.00)</points>
+        </wire>
+        <wire output="82" input="41" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="8" wireText="NET8" wireState="0">
+            <points>(642.00,847.00); (642.00,853.00); (308.00,853.00); (308.00,645.00); (320.00,645.00)</points>
+        </wire>
+        <wire output="21" input="75" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="9" wireText="NET9" wireState="0">
+            <points>(557.00,669.00); (557.00,756.00)</points>
+        </wire>
+        <wire output="25" input="76" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="10" wireText="NET10" wireState="0">
+            <points>(618.00,669.00); (618.00,756.00)</points>
+        </wire>
+        <wire output="22" input="77" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="11" wireText="NET11" wireState="0">
+            <points>(573.00,669.00); (573.00,756.00)</points>
+        </wire>
+        <wire output="23" input="78" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="12" wireText="NET12" wireState="0">
+            <points>(588.00,669.00); (588.00,756.00)</points>
+        </wire>
+        <wire output="26" input="79" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="13" wireText="NET13" wireState="0">
+            <points>(634.00,669.00); (634.00,756.00)</points>
+        </wire>
+        <wire output="27" input="80" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="14" wireText="NET14" wireState="0">
+            <points>(649.00,669.00); (649.00,756.00)</points>
+        </wire>
+        <wire output="28" input="81" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="15" wireText="NET15" wireState="0">
+            <points>(664.00,669.00); (664.00,756.00)</points>
+        </wire>
+        <wire output="24" input="82" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="16" wireText="NET16" wireState="0">
+            <points>(603.00,669.00); (603.00,756.00)</points>
+        </wire>
+        <wire output="29" input="83" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="17" wireText="NET17" wireState="0">
+            <points>(680.00,669.00); (680.00,756.00)</points>
+        </wire>
+        <wire output="30" input="84" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="18" wireText="NET18" wireState="0">
+            <points>(695.00,669.00); (695.00,756.00)</points>
+        </wire>
+        <wire output="80" input="39" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="20" wireText="NET20" wireState="0">
+            <points>(129.00,289.00); (116.00,289.00); (116.00,240.00); (308.00,240.00); (308.00,251.00); (320.00,251.00)</points>
+        </wire>
+        <wire output="34" input="67" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="21" wireText="NET21" wireState="0">
+            <points>(320.00,333.00); (220.00,333.00)</points>
+        </wire>
+        <wire output="38" input="68" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="22" wireText="NET22" wireState="0">
+            <points>(320.00,267.00); (220.00,267.00)</points>
+        </wire>
+        <wire output="37" input="69" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="23" wireText="NET23" wireState="0">
+            <points>(320.00,284.00); (220.00,284.00)</points>
+        </wire>
+        <wire output="36" input="70" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="24" wireText="NET24" wireState="0">
+            <points>(320.00,300.00); (220.00,300.00)</points>
+        </wire>
+        <wire output="35" input="71" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="25" wireText="NET25" wireState="0">
+            <points>(320.00,317.00); (220.00,317.00)</points>
+        </wire>
+        <wire output="33" input="72" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="26" wireText="NET26" wireState="0">
+            <points>(320.00,350.00); (220.00,350.00)</points>
+        </wire>
+        <wire output="32" input="73" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="27" wireText="NET27" wireState="0">
+            <points>(320.00,366.00); (220.00,366.00)</points>
+        </wire>
+        <wire output="41" input="0" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="28" wireText="NET28" wireState="0">
+            <points>(320.00,597.00); (97.00,597.00)</points>
+        </wire>
+        <wire output="42" input="1" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="29" wireText="NET29" wireState="0">
+            <points>(320.00,547.00); (212.00,547.00)</points>
+        </wire>
+        <wire output="43" input="2" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="30" wireText="NET30" wireState="0">
+            <points>(320.00,498.00); (97.00,498.00)</points>
+        </wire>
+        <wire output="44" input="3" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="31" wireText="NET31" wireState="0">
+            <points>(320.00,449.00); (212.00,449.00)</points>
+        </wire>
+        <wire output="45" input="4" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="32" wireText="NET32" wireState="0">
+            <points>(320.00,399.00); (97.00,399.00)</points>
+        </wire>
+        <wire output="46" input="5" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="33" wireText="NET33" wireState="0">
+            <points>(320.00,202.00); (97.00,202.00)</points>
+        </wire>
+        <wire output="47" input="6" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="34" wireText="NET34" wireState="0">
+            <points>(320.00,153.00); (212.00,153.00)</points>
+        </wire>
+        <wire output="48" input="7" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="35" wireText="NET35" wireState="0">
+            <points>(320.00,103.00); (97.00,103.00)</points>
+        </wire>
+        <wire output="49" input="8" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="36" wireText="NET36" wireState="0">
+            <points>(961.00,55.00); (1071.00,55.00)</points>
+        </wire>
+        <wire output="50" input="9" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="37" wireText="NET37" wireState="0">
+            <points>(961.00,107.00); (1177.00,107.00)</points>
+        </wire>
+        <wire output="51" input="10" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="38" wireText="NET38" wireState="0">
+            <points>(961.00,159.00); (1071.00,159.00)</points>
+        </wire>
+        <wire output="52" input="11" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="39" wireText="NET39" wireState="0">
+            <points>(961.00,211.00); (1177.00,211.00)</points>
+        </wire>
+        <wire output="53" input="12" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="40" wireText="NET40" wireState="0">
+            <points>(961.00,263.00); (1071.00,263.00)</points>
+        </wire>
+        <wire output="54" input="13" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="41" wireText="NET41" wireState="0">
+            <points>(961.00,315.00); (1177.00,315.00)</points>
+        </wire>
+        <wire output="55" input="14" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="42" wireText="NET42" wireState="0">
+            <points>(961.00,402.00); (1071.00,402.00)</points>
+        </wire>
+        <wire output="56" input="15" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="43" wireText="NET43" wireState="0">
+            <points>(961.00,454.00); (1177.00,454.00)</points>
+        </wire>
+        <wire output="57" input="16" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="44" wireText="NET44" wireState="0">
+            <points>(961.00,610.00); (1071.00,610.00)</points>
+        </wire>
+        <wire output="58" input="17" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="45" wireText="NET45" wireState="0">
+            <points>(961.00,558.00); (1177.00,558.00)</points>
+        </wire>
+        <wire output="59" input="18" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="46" wireText="NET46" wireState="0">
+            <points>(961.00,506.00); (1071.00,506.00)</points>
+        </wire>
+        <wire output="60" input="19" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="47" wireText="NET47" wireState="0">
+            <points>(320.00,630.00); (108.00,630.00); (108.00,648.00); (54.00,648.00); (54.00,633.00)</points>
+        </wire>
+        <wire output="61" input="20" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="48" wireText="NET48" wireState="0">
+            <points>(320.00,580.00); (220.00,580.00); (220.00,588.00); (169.00,588.00); (169.00,582.00)</points>
+        </wire>
+        <wire output="62" input="21" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="49" wireText="NET49" wireState="0">
+            <points>(320.00,531.00); (108.00,531.00); (108.00,552.00); (54.00,552.00); (54.00,534.00)</points>
+        </wire>
+        <wire output="63" input="22" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="50" wireText="NET50" wireState="0">
+            <points>(320.00,482.00); (220.00,482.00); (220.00,490.00); (169.00,490.00); (169.00,484.00)</points>
+        </wire>
+        <wire output="64" input="23" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="51" wireText="NET51" wireState="0">
+            <points>(320.00,432.00); (108.00,432.00); (108.00,448.00); (54.00,448.00); (54.00,435.00)</points>
+        </wire>
+        <wire output="65" input="24" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="52" wireText="NET52" wireState="0">
+            <points>(320.00,235.00); (108.00,235.00); (108.00,248.00); (54.00,248.00); (54.00,237.00)</points>
+        </wire>
+        <wire output="66" input="25" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="53" wireText="NET53" wireState="0">
+            <points>(320.00,185.00); (220.00,185.00); (220.00,194.00); (169.00,194.00); (169.00,188.00)</points>
+        </wire>
+        <wire output="67" input="26" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="54" wireText="NET54" wireState="0">
+            <points>(320.00,136.00); (108.00,136.00); (108.00,152.00); (54.00,152.00); (54.00,139.00)</points>
+        </wire>
+        <wire output="68" input="27" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="55" wireText="NET55" wireState="0">
+            <points>(961.00,90.00); (1060.00,90.00); (1060.00,96.00); (1113.00,96.00); (1113.00,90.00)</points>
+        </wire>
+        <wire output="69" input="28" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="56" wireText="NET56" wireState="0">
+            <points>(961.00,142.00); (1172.00,142.00); (1172.00,160.00); (1219.00,160.00); (1219.00,142.00)</points>
+        </wire>
+        <wire output="70" input="29" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="57" wireText="NET57" wireState="0">
+            <points>(961.00,194.00); (1060.00,194.00); (1060.00,200.00); (1113.00,200.00); (1113.00,194.00)</points>
+        </wire>
+        <wire output="71" input="30" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="58" wireText="NET58" wireState="0">
+            <points>(961.00,246.00); (1172.00,246.00); (1172.00,264.00); (1219.00,264.00); (1219.00,246.00)</points>
+        </wire>
+        <wire output="72" input="31" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="59" wireText="NET59" wireState="0">
+            <points>(961.00,298.00); (1060.00,298.00); (1060.00,304.00); (1113.00,304.00); (1113.00,298.00)</points>
+        </wire>
+        <wire output="73" input="32" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="60" wireText="NET60" wireState="0">
+            <points>(961.00,350.00); (1172.00,350.00); (1172.00,356.00); (1219.00,356.00); (1219.00,350.00)</points>
+        </wire>
+        <wire output="74" input="33" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="61" wireText="NET61" wireState="0">
+            <points>(961.00,437.00); (1060.00,437.00); (1060.00,443.00); (1113.00,443.00); (1113.00,437.00)</points>
+        </wire>
+        <wire output="75" input="34" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="62" wireText="NET62" wireState="0">
+            <points>(961.00,489.00); (1172.00,489.00); (1172.00,504.00); (1219.00,504.00); (1219.00,490.00)</points>
+        </wire>
+        <wire output="76" input="35" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="63" wireText="NET63" wireState="0">
+            <points>(961.00,645.00); (1060.00,645.00); (1060.00,664.00); (1113.00,664.00); (1113.00,645.00)</points>
+        </wire>
+        <wire output="77" input="36" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="64" wireText="NET64" wireState="0">
+            <points>(961.00,593.00); (1172.00,593.00); (1172.00,608.00); (1219.00,608.00); (1219.00,593.00)</points>
+        </wire>
+        <wire output="78" input="37" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="65" wireText="NET65" wireState="0">
+            <points>(961.00,541.00); (1060.00,541.00); (1060.00,547.00); (1113.00,547.00); (1113.00,541.00)</points>
+        </wire>
+        <wire output="0" input="42" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="66" wireText="NET66" wireState="0">
+            <points>(97.00,609.00); (314.00,609.00); (314.00,613.00); (320.00,613.00)</points>
+        </wire>
+        <wire output="1" input="43" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="67" wireText="NET67" wireState="0">
+            <points>(212.00,558.00); (314.00,558.00); (314.00,564.00); (320.00,564.00)</points>
+        </wire>
+        <wire output="2" input="44" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (314.00,510.00); (314.00,514.00); (320.00,514.00)</points>
+        </wire>
+        <wire output="3" input="45" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="68" wireText="NET68" wireState="0">
+            <points>(212.00,460.00); (314.00,460.00); (314.00,465.00); (320.00,465.00)</points>
+        </wire>
+        <wire output="4" input="46" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="69" wireText="NET69" wireState="0">
+            <points>(97.00,411.00); (314.00,411.00); (314.00,416.00); (320.00,416.00)</points>
+        </wire>
+        <wire output="5" input="47" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="70" wireText="NET70" wireState="0">
+            <points>(97.00,213.00); (314.00,213.00); (314.00,218.00); (320.00,218.00)</points>
+        </wire>
+        <wire output="6" input="48" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="71" wireText="NET71" wireState="0">
+            <points>(212.00,164.00); (314.00,164.00); (314.00,169.00); (320.00,169.00)</points>
+        </wire>
+        <wire output="7" input="49" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="72" wireText="NET72" wireState="0">
+            <points>(97.00,115.00); (314.00,115.00); (314.00,120.00); (320.00,120.00)</points>
+        </wire>
+        <wire output="8" input="50" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="73" wireText="NET73" wireState="0">
+            <points>(1071.00,66.00); (967.00,66.00); (967.00,72.00); (961.00,72.00)</points>
+        </wire>
+        <wire output="9" input="51" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="74" wireText="NET74" wireState="0">
+            <points>(1177.00,118.00); (967.00,118.00); (967.00,124.00); (961.00,124.00)</points>
+        </wire>
+        <wire output="10" input="52" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="75" wireText="NET75" wireState="0">
+            <points>(1071.00,170.00); (967.00,170.00); (967.00,176.00); (961.00,176.00)</points>
+        </wire>
+        <wire output="11" input="53" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="76" wireText="NET76" wireState="0">
+            <points>(1177.00,222.00); (967.00,222.00); (967.00,228.00); (961.00,228.00)</points>
+        </wire>
+        <wire output="12" input="54" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="77" wireText="NET77" wireState="0">
+            <points>(1071.00,275.00); (967.00,275.00); (967.00,280.00); (961.00,280.00)</points>
+        </wire>
+        <wire output="13" input="55" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="78" wireText="NET78" wireState="0">
+            <points>(1177.00,327.00); (967.00,327.00); (967.00,333.00); (961.00,333.00)</points>
+        </wire>
+        <wire output="14" input="56" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="79" wireText="NET79" wireState="0">
+            <points>(1071.00,413.00); (967.00,413.00); (967.00,419.00); (961.00,419.00)</points>
+        </wire>
+        <wire output="15" input="57" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="80" wireText="NET80" wireState="0">
+            <points>(1177.00,466.00); (967.00,466.00); (967.00,471.00); (961.00,471.00)</points>
+        </wire>
+        <wire output="16" input="58" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="81" wireText="NET81" wireState="0">
+            <points>(1071.00,621.00); (967.00,621.00); (967.00,628.00); (961.00,628.00)</points>
+        </wire>
+        <wire output="17" input="59" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="82" wireText="NET82" wireState="0">
+            <points>(1177.00,570.00); (967.00,570.00); (967.00,576.00); (961.00,576.00)</points>
+        </wire>
+        <wire output="18" input="60" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="83" wireText="NET83" wireState="0">
+            <points>(1071.00,518.00); (967.00,518.00); (967.00,524.00); (961.00,524.00)</points>
+        </wire>
+    </chip>
+    <emulatorConfiguration version="4" oldestCompatibleVersion="4">
+        <settings>
+            <autoApply value="0"/>
+            <platformSelector id="-1"/>
+        </settings>
+        <platform id="0" friendlyName="GreenPAK DIP Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="1" friendlyName="GreenPAK Advanced Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="2" friendlyName="GreenPAK Pro Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="4" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="5" friendlyName="GreenPAK Advanced Development Platform w/ Logic Level Adapter #1">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="6" friendlyName="ForgeFPGA Deluxe Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="7" friendlyName="ForgeFPGA Evaluation Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="8" friendlyName="SLG51000 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="9" friendlyName="SLG51001 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="10" friendlyName="SLG51002 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="11" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="12" friendlyName="GreenPAK Lite Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="13" friendlyName="HVPAK Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="14" friendlyName="SLG47105V Training Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="15" friendlyName="Power GreenPAK Development Motherboard">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="16" friendlyName="ForgeFPGA Deluxe Development Platform Rev. 2.0">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="17" friendlyName="HVPAK SLG47125 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+    </emulatorConfiguration>
+    <fpga-data>
+        <!--Fpga project data-->
+        <project-data-version>5</project-data-version>
+        <oldestCompatibleVersion>3</oldestCompatibleVersion>
+        <settings>
+            <generateBitstream>
+                <MAX_CPU>16</MAX_CPU>
+                <additionalArguments></additionalArguments>
+                <clockConcurrentOptimization>true</clockConcurrentOptimization>
+                <highDensityIOPacking>false</highDensityIOPacking>
+                <highDensityPackingLogic>true</highDensityPackingLogic>
+                <maximumRoutingIterations>300</maximumRoutingIterations>
+                <placeAndTrialRoute>false</placeAndTrialRoute>
+                <placeAndTrialRouteIterationCount>20</placeAndTrialRouteIterationCount>
+            </generateBitstream>
+            <simulation>
+                <wavedumpOutputFormat>1</wavedumpOutputFormat>
+            </simulation>
+            <synthesize>
+                <additionalArguments></additionalArguments>
+                <flatten>true</flatten>
+                <keep>false</keep>
+                <noDSP>true</noDSP>
+                <useABC9>true</useABC9>
+            </synthesize>
+        </settings>
+        <openedTabs>
+            <openedTab>main.v</openedTab>
+            <openedTab>I/O Planner</openedTab>
+        </openedTabs>
+        <pipelineStagesStates>
+            <pipelineStageState>
+                <pipelineStage>0</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+            <pipelineStageState>
+                <pipelineStage>1</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+        </pipelineStagesStates>
+        <modules>
+            <scr>
+                <module filename="main.v"/>
+            </scr>
+            <lib/>
+            <sim/>
+            <netlists/>
+            <timing-constraints/>
+        </modules>
+        <io-spec-tool>
+            <records filter="16">
+                <record id="IOB_t[0:0]_xy[31:4]_in0">
+                    <port-name>b</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:5]_in0">
+                    <port-name>a</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:6]_in0">
+                    <port-name>LED_en</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:6]_out1">
+                    <port-name>LED</port-name>
+                </record>
+            </records>
+        </io-spec-tool>
+        <macrocell-mode-data>
+            <scene-data>
+                <scene-width>32767</scene-width>
+                <scene-height>32767</scene-height>
+                <scene-snapToGrid>1</scene-snapToGrid>
+            </scene-data>
+            <macrocells-data>
+                <macrocell>
+                    <macrocell-id>18</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input18</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>-240</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>19</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>20</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input20</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>21</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>22</macrocell-id>
+                    <macrocell-type>4</macrocell-type>
+                    <macrocell-title>NOT Gate</macrocell-title>
+                    <macrocell-name>not22</macrocell-name>
+                    <macrocell-posx>-100</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>23</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>24</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>25</macrocell-id>
+                    <macrocell-type>8</macrocell-type>
+                    <macrocell-title>NAND Gate</macrocell-title>
+                    <macrocell-name>nand25</macrocell-name>
+                    <macrocell-posx>240</macrocell-posx>
+                    <macrocell-posy>-200</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>26</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                        <port>
+                            <port-id>27</port-id>
+                            <port-index>1</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>28</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>29</macrocell-id>
+                    <macrocell-type>3</macrocell-type>
+                    <macrocell-title>OUT</macrocell-title>
+                    <macrocell-name>output29</macrocell-name>
+                    <macrocell-posx>640</macrocell-posx>
+                    <macrocell-posy>-140</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>30</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports/>
+                </macrocell>
+            </macrocells-data>
+            <wires-data>
+                <wire>
+                    <wire-id>31</wire-id>
+                    <wire-start-port-id>19</wire-start-port-id>
+                    <wire-end-port-id>26</wire-end-port-id>
+                    <wire-name>wire31</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>32</wire-id>
+                    <wire-start-port-id>21</wire-start-port-id>
+                    <wire-end-port-id>23</wire-end-port-id>
+                    <wire-name>wire32</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>33</wire-id>
+                    <wire-start-port-id>24</wire-start-port-id>
+                    <wire-end-port-id>27</wire-end-port-id>
+                    <wire-name>wire33</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>34</wire-id>
+                    <wire-start-port-id>28</wire-start-port-id>
+                    <wire-end-port-id>30</wire-end-port-id>
+                    <wire-name>wire34</wire-name>
+                </wire>
+            </wires-data>
+        </macrocell-mode-data>
+        <!--Fpga project data END-->
+    </fpga-data>
+    <projectData>
+        <specs>
+            <lastModify lastModifyValue="11.11.2025 11:14:51"/>
+            <vddSpecs vddMin="1.05" vddTyp="1.05" vddMax="1.15"/>
+            <vdd2Specs vdd2Min="1.71" vdd2Typ="2.5" vdd2Max="3.3"/>
+            <tempSpecs tempMin="-40" tempTyp="25" tempMax="85"/>
+        </specs>
+        <projectDataFields>
+            <textLineDataField name="Customer Name" id="2" text=""/>
+            <textLineDataField name="Customer Project Name" id="3" text=""/>
+            <textLineDataField name="Customer Project Number" id="4" text=""/>
+            <textLineDataField name="Customer Version Number" id="5" text=""/>
+            <multiTextLineDataField>
+                <textLineDataField name="Notes" id="6" text=""/>
+            </multiTextLineDataField>
+        </projectDataFields>
+    </projectData>
+    <i2cTool>
+        <i2cDebugger version="1"/>
+        <i2cStepper version="1" rowCount="0"/>
+        <i2cRegsTable version="1" tabCount="0"/>
+    </i2cTool>
+<logicAnalyzer>
+    <metadata>
+        <autosavePreset>-1</autosavePreset>
+        <currentPreset>-1</currentPreset>
+        <version>3</version>
+    </metadata>
+    <presetList/>
+</logicAnalyzer>
+
+</GPDProject>

--- a/Projects/logic_gates/nor/ffpga/src/main.v
+++ b/Projects/logic_gates/nor/ffpga/src/main.v
@@ -1,0 +1,43 @@
+//-----------------------------------------------------------------------------
+// Company:         Vicharak Computers PVT LTD
+// Engineer:        Shashank Bhosagi <shashankbhosagi0121@gmail.com>
+// 
+// Create Date:     NOV 11, 2025
+// Design Name:     Basic Logic Gates
+// Module Name:     nor_gate
+// Project:         Shrike-Lite Examples
+// Target Device:   Shrike-Lite (RP2040 + Renesas FPGA (SLG47910V))
+// Tool Versions:   Go Configure Software Hub v.6.48
+// 
+// Description: 
+//    Simple 2-input NOR gate implementation for beginners exploring
+//    FPGA design using Verilog on the Shrike-Lite.
+// Dependencies: 
+// None
+//
+// Version:
+//    1.0 - 11/11/2025 - Initial release
+// 
+// Additional Comments: 
+//    This project is part of https://github.com/vicharak-in/shrike-lite.
+//    All logic gate examples (AND, OR, NOT, NAND, NOR, XOR) are
+//    available under the same structure. 
+// License: 
+//    Open Source — MIT License
+//    Copyright © 2025 Vicharak Computers Pvt. Ltd
+//-----------------------------------------------------------------------------
+
+(* top *) module nor_gate(
+  (* iopad_external_pin *) output LED,
+  (* iopad_external_pin *) output LED_en,
+  (* iopad_external_pin *) input a,  
+  (* iopad_external_pin *) input b,
+  );
+  
+  assign LED_en = 1'b1;
+  wire or_output;
+  
+  assign or_output = a | b;
+  assign LED = ~(or_output);
+  
+endmodule

--- a/Projects/logic_gates/nor/nor.ffpga
+++ b/Projects/logic_gates/nor/nor.ffpga
@@ -1,0 +1,846 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GPDProject version="37" oldestCompatibleVersion="32" GPDVersion="6.48.001" lastChange="11 Nov 2025 17:29:58" projectChecksumState="1" projectChecksum="bdc9471e">
+    <generalProjectSettings/>
+    <chip family="04" type="06" friendlyName="FFPGA" partNumber="67" package="26">
+        <nvmData registerLenght="480">0 0 0 28 0 0 0 0 A5 A5 A5 A5 0 0 0 0 0 0 0 0 5A 5A 5A 5A 0 0 0 0 22 22 22 22 22 22 22 22 22 22 0 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</nvmData>
+        <checksum crc32="0x451C1D42" version="2"/>
+        <VDDItem id="0">
+            <item id="0" caption="VDD (PIN 22)">
+                <graphics pos="(1350.00,143.10)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <VDDItem id="1">
+            <item id="1" caption="VDDIO (PIN 21)">
+                <graphics pos="(1350.00,226.67)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <item id="2" caption="GND (PIN 12)">
+            <graphics pos="(1350.00,298.48)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="3" caption="FPGA">
+            <graphics pos="(0.00,0.00)" angle="0" flipping="0" hidden="0" tOrigin="(640.00,442.50)"/>
+        </item>
+        <item id="4" caption="GPIO0 (PIN 13)">
+            <graphics pos="(35.00,592.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="5" caption="GPIO1 (PIN 14)">
+            <graphics pos="(150.00,542.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="6" caption="GPIO2 (PIN 15)">
+            <graphics pos="(35.00,493.59)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="7" caption="GPIO3 (PIN 16)">
+            <graphics pos="(150.00,444.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="8" caption="GPIO4 (PIN 17)">
+            <graphics pos="(35.00,394.74)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="9" caption="GPIO5 (PIN 18)">
+            <graphics pos="(35.00,197.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="10" caption="GPIO6 (PIN 19)">
+            <graphics pos="(150.00,148.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="11" caption="GPIO7 (PIN 20)">
+            <graphics pos="(35.00,98.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="12" caption="GPIO8 (PIN 23)">
+            <graphics pos="(1094.00,49.99)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="13" caption="GPIO9 (PIN 24)">
+            <graphics pos="(1200.00,102.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="14" caption="GPIO10 (PIN 1)">
+            <graphics pos="(1094.00,154.03)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="15" caption="GPIO11 (PIN 2)">
+            <graphics pos="(1200.00,206.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="16" caption="GPIO12 (PIN 3)">
+            <graphics pos="(1094.00,258.20)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="17" caption="GPIO13 (PIN 4)">
+            <graphics pos="(1200.00,310.28)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="18" caption="GPIO14 (PIN 5)">
+            <graphics pos="(1094.00,397.09)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="19" caption="GPIO15 (PIN 6)">
+            <graphics pos="(1200.00,449.75)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="20" caption="GPIO18 (PIN 9/GrP0)">
+            <graphics pos="(1094.00,604.84)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="21" caption="GPIO17 (PIN 8/GrP1)">
+            <graphics pos="(1200.00,553.34)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="22" caption="GPIO16 (PIN 7/GrP2)">
+            <graphics pos="(1094.00,501.25)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="23" caption="nRST (PIN 11)">
+            <graphics pos="(1094.00,356.17)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="24" caption="nSLEEP (PIN 10)">
+            <graphics pos="(1200.00,374.22)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="25" caption="OSC">
+            <graphics pos="(150.00,64.53)" angle="0" flipping="0" hidden="0" tOrigin="(25.00,10.00)"/>
+        </item>
+        <item id="26" caption="Phase-Locked Loop">
+            <graphics pos="(149.73,246.87)" angle="180" flipping="0" hidden="0" tOrigin="(25.00,70.00)"/>
+        </item>
+        <item id="27" caption="BRAM">
+            <graphics pos="(616.77,701.83)" angle="90" flipping="0" hidden="0" tOrigin="(25.00,100.00)"/>
+        </item>
+        <item id="28" caption="FPGA Core">
+            <graphics pos="(340.90,49.43)" angle="0" flipping="0" hidden="0" tOrigin="(300.00,300.00)"/>
+        </item>
+        <wire output="79" input="65" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (236.00,80.00); (236.00,250.00); (220.00,250.00)</points>
+        </wire>
+        <wire output="2" input="66" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (226.00,510.00); (226.00,383.00); (220.00,383.00)</points>
+        </wire>
+        <wire output="83" input="85" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="0" wireText="NET0" wireState="0">
+            <points>(129.00,344.00); (116.00,344.00); (116.00,392.00); (308.00,392.00); (308.00,383.00); (320.00,383.00)</points>
+        </wire>
+        <wire output="84" input="86" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="1" wireText="NET1" wireState="0">
+            <points>(711.00,669.00); (711.00,756.00)</points>
+        </wire>
+        <wire output="85" input="87" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="2" wireText="NET2" wireState="0">
+            <points>(726.00,669.00); (726.00,756.00)</points>
+        </wire>
+        <wire output="86" input="88" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="3" wireText="NET3" wireState="0">
+            <points>(220.00,70.00); (320.00,70.00)</points>
+        </wire>
+        <wire output="79" input="38" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (314.00,80.00); (314.00,87.00); (320.00,87.00)</points>
+        </wire>
+        <wire output="39" input="63" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="5" wireText="NET5" wireState="0">
+            <points>(320.00,54.00); (116.00,54.00); (116.00,75.00); (129.00,75.00)</points>
+        </wire>
+        <wire output="20" input="62" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="6" wireText="NET6" wireState="0">
+            <points>(1177.00,384.00); (967.00,384.00); (967.00,385.00); (961.00,385.00)</points>
+        </wire>
+        <wire output="19" input="61" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="7" wireText="NET7" wireState="0">
+            <points>(1071.00,366.00); (967.00,366.00); (967.00,367.00); (961.00,367.00)</points>
+        </wire>
+        <wire output="82" input="41" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="8" wireText="NET8" wireState="0">
+            <points>(642.00,847.00); (642.00,853.00); (308.00,853.00); (308.00,645.00); (320.00,645.00)</points>
+        </wire>
+        <wire output="21" input="75" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="9" wireText="NET9" wireState="0">
+            <points>(557.00,669.00); (557.00,756.00)</points>
+        </wire>
+        <wire output="25" input="76" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="10" wireText="NET10" wireState="0">
+            <points>(618.00,669.00); (618.00,756.00)</points>
+        </wire>
+        <wire output="22" input="77" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="11" wireText="NET11" wireState="0">
+            <points>(573.00,669.00); (573.00,756.00)</points>
+        </wire>
+        <wire output="23" input="78" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="12" wireText="NET12" wireState="0">
+            <points>(588.00,669.00); (588.00,756.00)</points>
+        </wire>
+        <wire output="26" input="79" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="13" wireText="NET13" wireState="0">
+            <points>(634.00,669.00); (634.00,756.00)</points>
+        </wire>
+        <wire output="27" input="80" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="14" wireText="NET14" wireState="0">
+            <points>(649.00,669.00); (649.00,756.00)</points>
+        </wire>
+        <wire output="28" input="81" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="15" wireText="NET15" wireState="0">
+            <points>(664.00,669.00); (664.00,756.00)</points>
+        </wire>
+        <wire output="24" input="82" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="16" wireText="NET16" wireState="0">
+            <points>(603.00,669.00); (603.00,756.00)</points>
+        </wire>
+        <wire output="29" input="83" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="17" wireText="NET17" wireState="0">
+            <points>(680.00,669.00); (680.00,756.00)</points>
+        </wire>
+        <wire output="30" input="84" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="18" wireText="NET18" wireState="0">
+            <points>(695.00,669.00); (695.00,756.00)</points>
+        </wire>
+        <wire output="80" input="39" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="20" wireText="NET20" wireState="0">
+            <points>(129.00,289.00); (116.00,289.00); (116.00,240.00); (308.00,240.00); (308.00,251.00); (320.00,251.00)</points>
+        </wire>
+        <wire output="34" input="67" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="21" wireText="NET21" wireState="0">
+            <points>(320.00,333.00); (220.00,333.00)</points>
+        </wire>
+        <wire output="38" input="68" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="22" wireText="NET22" wireState="0">
+            <points>(320.00,267.00); (220.00,267.00)</points>
+        </wire>
+        <wire output="37" input="69" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="23" wireText="NET23" wireState="0">
+            <points>(320.00,284.00); (220.00,284.00)</points>
+        </wire>
+        <wire output="36" input="70" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="24" wireText="NET24" wireState="0">
+            <points>(320.00,300.00); (220.00,300.00)</points>
+        </wire>
+        <wire output="35" input="71" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="25" wireText="NET25" wireState="0">
+            <points>(320.00,317.00); (220.00,317.00)</points>
+        </wire>
+        <wire output="33" input="72" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="26" wireText="NET26" wireState="0">
+            <points>(320.00,350.00); (220.00,350.00)</points>
+        </wire>
+        <wire output="32" input="73" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="27" wireText="NET27" wireState="0">
+            <points>(320.00,366.00); (220.00,366.00)</points>
+        </wire>
+        <wire output="41" input="0" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="28" wireText="NET28" wireState="0">
+            <points>(320.00,597.00); (97.00,597.00)</points>
+        </wire>
+        <wire output="42" input="1" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="29" wireText="NET29" wireState="0">
+            <points>(320.00,547.00); (212.00,547.00)</points>
+        </wire>
+        <wire output="43" input="2" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="30" wireText="NET30" wireState="0">
+            <points>(320.00,498.00); (97.00,498.00)</points>
+        </wire>
+        <wire output="44" input="3" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="31" wireText="NET31" wireState="0">
+            <points>(320.00,449.00); (212.00,449.00)</points>
+        </wire>
+        <wire output="45" input="4" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="32" wireText="NET32" wireState="0">
+            <points>(320.00,399.00); (97.00,399.00)</points>
+        </wire>
+        <wire output="46" input="5" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="33" wireText="NET33" wireState="0">
+            <points>(320.00,202.00); (97.00,202.00)</points>
+        </wire>
+        <wire output="47" input="6" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="34" wireText="NET34" wireState="0">
+            <points>(320.00,153.00); (212.00,153.00)</points>
+        </wire>
+        <wire output="48" input="7" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="35" wireText="NET35" wireState="0">
+            <points>(320.00,103.00); (97.00,103.00)</points>
+        </wire>
+        <wire output="49" input="8" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="36" wireText="NET36" wireState="0">
+            <points>(961.00,55.00); (1071.00,55.00)</points>
+        </wire>
+        <wire output="50" input="9" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="37" wireText="NET37" wireState="0">
+            <points>(961.00,107.00); (1177.00,107.00)</points>
+        </wire>
+        <wire output="51" input="10" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="38" wireText="NET38" wireState="0">
+            <points>(961.00,159.00); (1071.00,159.00)</points>
+        </wire>
+        <wire output="52" input="11" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="39" wireText="NET39" wireState="0">
+            <points>(961.00,211.00); (1177.00,211.00)</points>
+        </wire>
+        <wire output="53" input="12" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="40" wireText="NET40" wireState="0">
+            <points>(961.00,263.00); (1071.00,263.00)</points>
+        </wire>
+        <wire output="54" input="13" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="41" wireText="NET41" wireState="0">
+            <points>(961.00,315.00); (1177.00,315.00)</points>
+        </wire>
+        <wire output="55" input="14" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="42" wireText="NET42" wireState="0">
+            <points>(961.00,402.00); (1071.00,402.00)</points>
+        </wire>
+        <wire output="56" input="15" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="43" wireText="NET43" wireState="0">
+            <points>(961.00,454.00); (1177.00,454.00)</points>
+        </wire>
+        <wire output="57" input="16" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="44" wireText="NET44" wireState="0">
+            <points>(961.00,610.00); (1071.00,610.00)</points>
+        </wire>
+        <wire output="58" input="17" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="45" wireText="NET45" wireState="0">
+            <points>(961.00,558.00); (1177.00,558.00)</points>
+        </wire>
+        <wire output="59" input="18" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="46" wireText="NET46" wireState="0">
+            <points>(961.00,506.00); (1071.00,506.00)</points>
+        </wire>
+        <wire output="60" input="19" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="47" wireText="NET47" wireState="0">
+            <points>(320.00,630.00); (108.00,630.00); (108.00,648.00); (54.00,648.00); (54.00,633.00)</points>
+        </wire>
+        <wire output="61" input="20" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="48" wireText="NET48" wireState="0">
+            <points>(320.00,580.00); (220.00,580.00); (220.00,588.00); (169.00,588.00); (169.00,582.00)</points>
+        </wire>
+        <wire output="62" input="21" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="49" wireText="NET49" wireState="0">
+            <points>(320.00,531.00); (108.00,531.00); (108.00,552.00); (54.00,552.00); (54.00,534.00)</points>
+        </wire>
+        <wire output="63" input="22" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="50" wireText="NET50" wireState="0">
+            <points>(320.00,482.00); (220.00,482.00); (220.00,490.00); (169.00,490.00); (169.00,484.00)</points>
+        </wire>
+        <wire output="64" input="23" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="51" wireText="NET51" wireState="0">
+            <points>(320.00,432.00); (108.00,432.00); (108.00,448.00); (54.00,448.00); (54.00,435.00)</points>
+        </wire>
+        <wire output="65" input="24" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="52" wireText="NET52" wireState="0">
+            <points>(320.00,235.00); (108.00,235.00); (108.00,248.00); (54.00,248.00); (54.00,237.00)</points>
+        </wire>
+        <wire output="66" input="25" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="53" wireText="NET53" wireState="0">
+            <points>(320.00,185.00); (220.00,185.00); (220.00,194.00); (169.00,194.00); (169.00,188.00)</points>
+        </wire>
+        <wire output="67" input="26" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="54" wireText="NET54" wireState="0">
+            <points>(320.00,136.00); (108.00,136.00); (108.00,152.00); (54.00,152.00); (54.00,139.00)</points>
+        </wire>
+        <wire output="68" input="27" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="55" wireText="NET55" wireState="0">
+            <points>(961.00,90.00); (1060.00,90.00); (1060.00,96.00); (1113.00,96.00); (1113.00,90.00)</points>
+        </wire>
+        <wire output="69" input="28" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="56" wireText="NET56" wireState="0">
+            <points>(961.00,142.00); (1172.00,142.00); (1172.00,160.00); (1219.00,160.00); (1219.00,142.00)</points>
+        </wire>
+        <wire output="70" input="29" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="57" wireText="NET57" wireState="0">
+            <points>(961.00,194.00); (1060.00,194.00); (1060.00,200.00); (1113.00,200.00); (1113.00,194.00)</points>
+        </wire>
+        <wire output="71" input="30" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="58" wireText="NET58" wireState="0">
+            <points>(961.00,246.00); (1172.00,246.00); (1172.00,264.00); (1219.00,264.00); (1219.00,246.00)</points>
+        </wire>
+        <wire output="72" input="31" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="59" wireText="NET59" wireState="0">
+            <points>(961.00,298.00); (1060.00,298.00); (1060.00,304.00); (1113.00,304.00); (1113.00,298.00)</points>
+        </wire>
+        <wire output="73" input="32" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="60" wireText="NET60" wireState="0">
+            <points>(961.00,350.00); (1172.00,350.00); (1172.00,356.00); (1219.00,356.00); (1219.00,350.00)</points>
+        </wire>
+        <wire output="74" input="33" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="61" wireText="NET61" wireState="0">
+            <points>(961.00,437.00); (1060.00,437.00); (1060.00,443.00); (1113.00,443.00); (1113.00,437.00)</points>
+        </wire>
+        <wire output="75" input="34" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="62" wireText="NET62" wireState="0">
+            <points>(961.00,489.00); (1172.00,489.00); (1172.00,504.00); (1219.00,504.00); (1219.00,490.00)</points>
+        </wire>
+        <wire output="76" input="35" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="63" wireText="NET63" wireState="0">
+            <points>(961.00,645.00); (1060.00,645.00); (1060.00,664.00); (1113.00,664.00); (1113.00,645.00)</points>
+        </wire>
+        <wire output="77" input="36" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="64" wireText="NET64" wireState="0">
+            <points>(961.00,593.00); (1172.00,593.00); (1172.00,608.00); (1219.00,608.00); (1219.00,593.00)</points>
+        </wire>
+        <wire output="78" input="37" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="65" wireText="NET65" wireState="0">
+            <points>(961.00,541.00); (1060.00,541.00); (1060.00,547.00); (1113.00,547.00); (1113.00,541.00)</points>
+        </wire>
+        <wire output="0" input="42" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="66" wireText="NET66" wireState="0">
+            <points>(97.00,609.00); (314.00,609.00); (314.00,613.00); (320.00,613.00)</points>
+        </wire>
+        <wire output="1" input="43" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="67" wireText="NET67" wireState="0">
+            <points>(212.00,558.00); (314.00,558.00); (314.00,564.00); (320.00,564.00)</points>
+        </wire>
+        <wire output="2" input="44" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (314.00,510.00); (314.00,514.00); (320.00,514.00)</points>
+        </wire>
+        <wire output="3" input="45" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="68" wireText="NET68" wireState="0">
+            <points>(212.00,460.00); (314.00,460.00); (314.00,465.00); (320.00,465.00)</points>
+        </wire>
+        <wire output="4" input="46" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="69" wireText="NET69" wireState="0">
+            <points>(97.00,411.00); (314.00,411.00); (314.00,416.00); (320.00,416.00)</points>
+        </wire>
+        <wire output="5" input="47" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="70" wireText="NET70" wireState="0">
+            <points>(97.00,213.00); (314.00,213.00); (314.00,218.00); (320.00,218.00)</points>
+        </wire>
+        <wire output="6" input="48" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="71" wireText="NET71" wireState="0">
+            <points>(212.00,164.00); (314.00,164.00); (314.00,169.00); (320.00,169.00)</points>
+        </wire>
+        <wire output="7" input="49" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="72" wireText="NET72" wireState="0">
+            <points>(97.00,115.00); (314.00,115.00); (314.00,120.00); (320.00,120.00)</points>
+        </wire>
+        <wire output="8" input="50" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="73" wireText="NET73" wireState="0">
+            <points>(1071.00,66.00); (967.00,66.00); (967.00,72.00); (961.00,72.00)</points>
+        </wire>
+        <wire output="9" input="51" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="74" wireText="NET74" wireState="0">
+            <points>(1177.00,118.00); (967.00,118.00); (967.00,124.00); (961.00,124.00)</points>
+        </wire>
+        <wire output="10" input="52" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="75" wireText="NET75" wireState="0">
+            <points>(1071.00,170.00); (967.00,170.00); (967.00,176.00); (961.00,176.00)</points>
+        </wire>
+        <wire output="11" input="53" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="76" wireText="NET76" wireState="0">
+            <points>(1177.00,222.00); (967.00,222.00); (967.00,228.00); (961.00,228.00)</points>
+        </wire>
+        <wire output="12" input="54" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="77" wireText="NET77" wireState="0">
+            <points>(1071.00,275.00); (967.00,275.00); (967.00,280.00); (961.00,280.00)</points>
+        </wire>
+        <wire output="13" input="55" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="78" wireText="NET78" wireState="0">
+            <points>(1177.00,327.00); (967.00,327.00); (967.00,333.00); (961.00,333.00)</points>
+        </wire>
+        <wire output="14" input="56" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="79" wireText="NET79" wireState="0">
+            <points>(1071.00,413.00); (967.00,413.00); (967.00,419.00); (961.00,419.00)</points>
+        </wire>
+        <wire output="15" input="57" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="80" wireText="NET80" wireState="0">
+            <points>(1177.00,466.00); (967.00,466.00); (967.00,471.00); (961.00,471.00)</points>
+        </wire>
+        <wire output="16" input="58" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="81" wireText="NET81" wireState="0">
+            <points>(1071.00,621.00); (967.00,621.00); (967.00,628.00); (961.00,628.00)</points>
+        </wire>
+        <wire output="17" input="59" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="82" wireText="NET82" wireState="0">
+            <points>(1177.00,570.00); (967.00,570.00); (967.00,576.00); (961.00,576.00)</points>
+        </wire>
+        <wire output="18" input="60" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="83" wireText="NET83" wireState="0">
+            <points>(1071.00,518.00); (967.00,518.00); (967.00,524.00); (961.00,524.00)</points>
+        </wire>
+    </chip>
+    <emulatorConfiguration version="4" oldestCompatibleVersion="4">
+        <settings>
+            <autoApply value="0"/>
+            <platformSelector id="-1"/>
+        </settings>
+        <platform id="0" friendlyName="GreenPAK DIP Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="1" friendlyName="GreenPAK Advanced Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="2" friendlyName="GreenPAK Pro Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="4" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="5" friendlyName="GreenPAK Advanced Development Platform w/ Logic Level Adapter #1">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="6" friendlyName="ForgeFPGA Deluxe Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="7" friendlyName="ForgeFPGA Evaluation Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="8" friendlyName="SLG51000 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="9" friendlyName="SLG51001 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="10" friendlyName="SLG51002 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="11" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="12" friendlyName="GreenPAK Lite Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="13" friendlyName="HVPAK Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="14" friendlyName="SLG47105V Training Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="15" friendlyName="Power GreenPAK Development Motherboard">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="16" friendlyName="ForgeFPGA Deluxe Development Platform Rev. 2.0">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="17" friendlyName="HVPAK SLG47125 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+    </emulatorConfiguration>
+    <fpga-data>
+        <!--Fpga project data-->
+        <project-data-version>5</project-data-version>
+        <oldestCompatibleVersion>3</oldestCompatibleVersion>
+        <settings>
+            <generateBitstream>
+                <MAX_CPU>16</MAX_CPU>
+                <additionalArguments></additionalArguments>
+                <clockConcurrentOptimization>true</clockConcurrentOptimization>
+                <highDensityIOPacking>false</highDensityIOPacking>
+                <highDensityPackingLogic>true</highDensityPackingLogic>
+                <maximumRoutingIterations>300</maximumRoutingIterations>
+                <placeAndTrialRoute>false</placeAndTrialRoute>
+                <placeAndTrialRouteIterationCount>20</placeAndTrialRouteIterationCount>
+            </generateBitstream>
+            <simulation>
+                <wavedumpOutputFormat>1</wavedumpOutputFormat>
+            </simulation>
+            <synthesize>
+                <additionalArguments></additionalArguments>
+                <flatten>true</flatten>
+                <keep>false</keep>
+                <noDSP>true</noDSP>
+                <useABC9>true</useABC9>
+            </synthesize>
+        </settings>
+        <openedTabs>
+            <openedTab>main.v</openedTab>
+            <openedTab>I/O Planner</openedTab>
+        </openedTabs>
+        <pipelineStagesStates>
+            <pipelineStageState>
+                <pipelineStage>0</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+            <pipelineStageState>
+                <pipelineStage>1</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+        </pipelineStagesStates>
+        <modules>
+            <scr>
+                <module filename="main.v"/>
+            </scr>
+            <lib/>
+            <sim/>
+            <netlists/>
+            <timing-constraints/>
+        </modules>
+        <io-spec-tool>
+            <records filter="16">
+                <record id="IOB_t[0:0]_xy[31:4]_in0">
+                    <port-name>b</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:5]_in0">
+                    <port-name>a</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:6]_out0">
+                    <port-name>LED</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:6]_out1">
+                    <port-name>LED_en</port-name>
+                </record>
+            </records>
+        </io-spec-tool>
+        <macrocell-mode-data>
+            <scene-data>
+                <scene-width>32767</scene-width>
+                <scene-height>32767</scene-height>
+                <scene-snapToGrid>1</scene-snapToGrid>
+            </scene-data>
+            <macrocells-data>
+                <macrocell>
+                    <macrocell-id>18</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input18</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>-240</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>19</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>20</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input20</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>21</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>22</macrocell-id>
+                    <macrocell-type>4</macrocell-type>
+                    <macrocell-title>NOT Gate</macrocell-title>
+                    <macrocell-name>not22</macrocell-name>
+                    <macrocell-posx>-100</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>23</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>24</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>25</macrocell-id>
+                    <macrocell-type>8</macrocell-type>
+                    <macrocell-title>NAND Gate</macrocell-title>
+                    <macrocell-name>nand25</macrocell-name>
+                    <macrocell-posx>240</macrocell-posx>
+                    <macrocell-posy>-200</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>26</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                        <port>
+                            <port-id>27</port-id>
+                            <port-index>1</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>28</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>29</macrocell-id>
+                    <macrocell-type>3</macrocell-type>
+                    <macrocell-title>OUT</macrocell-title>
+                    <macrocell-name>output29</macrocell-name>
+                    <macrocell-posx>640</macrocell-posx>
+                    <macrocell-posy>-140</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>30</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports/>
+                </macrocell>
+            </macrocells-data>
+            <wires-data>
+                <wire>
+                    <wire-id>31</wire-id>
+                    <wire-start-port-id>19</wire-start-port-id>
+                    <wire-end-port-id>26</wire-end-port-id>
+                    <wire-name>wire31</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>32</wire-id>
+                    <wire-start-port-id>21</wire-start-port-id>
+                    <wire-end-port-id>23</wire-end-port-id>
+                    <wire-name>wire32</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>33</wire-id>
+                    <wire-start-port-id>24</wire-start-port-id>
+                    <wire-end-port-id>27</wire-end-port-id>
+                    <wire-name>wire33</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>34</wire-id>
+                    <wire-start-port-id>28</wire-start-port-id>
+                    <wire-end-port-id>30</wire-end-port-id>
+                    <wire-name>wire34</wire-name>
+                </wire>
+            </wires-data>
+        </macrocell-mode-data>
+        <!--Fpga project data END-->
+    </fpga-data>
+    <projectData>
+        <specs>
+            <lastModify lastModifyValue="11.11.2025 11:58:02"/>
+            <vddSpecs vddMin="1.05" vddTyp="1.1" vddMax="1.15"/>
+            <vdd2Specs vdd2Min="1.71" vdd2Typ="2.5" vdd2Max="3.3"/>
+            <tempSpecs tempMin="-40" tempTyp="25" tempMax="85"/>
+        </specs>
+        <projectDataFields>
+            <textLineDataField name="Customer Name" id="2" text=""/>
+            <textLineDataField name="Customer Project Name" id="3" text=""/>
+            <textLineDataField name="Customer Project Number" id="4" text=""/>
+            <textLineDataField name="Customer Version Number" id="5" text=""/>
+            <multiTextLineDataField>
+                <textLineDataField name="Notes" id="6" text=""/>
+            </multiTextLineDataField>
+        </projectDataFields>
+    </projectData>
+    <i2cTool>
+        <i2cDebugger version="1"/>
+        <i2cStepper version="1" rowCount="0"/>
+        <i2cRegsTable version="1" tabCount="0"/>
+    </i2cTool>
+<logicAnalyzer>
+    <metadata>
+        <autosavePreset>-1</autosavePreset>
+        <currentPreset>-1</currentPreset>
+        <version>3</version>
+    </metadata>
+    <presetList/>
+</logicAnalyzer>
+
+</GPDProject>

--- a/Projects/logic_gates/not/ffpga/src/main.v
+++ b/Projects/logic_gates/not/ffpga/src/main.v
@@ -1,0 +1,39 @@
+//-----------------------------------------------------------------------------
+// Company:         Vicharak Computers PVT LTD
+// Engineer:        Shashank Bhosagi <shashankbhosagi0121@gmail.com>
+// 
+// Create Date:     NOV 11, 2025
+// Design Name:     Basic Logic Gates
+// Module Name:     not_gate
+// Project:         Shrike-Lite Examples
+// Target Device:   Shrike-Lite (RP2040 + Renesas FPGA (SLG47910V))
+// Tool Versions:   Go Configure Software Hub v.6.48
+// 
+// Description: 
+//    Simple single input NOT gate implementation for beginners exploring
+//    FPGA design using Verilog on the Shrike-Lite.
+// Dependencies: 
+// None
+//
+// Version:
+//    1.0 - 11/11/2025 - Initial release
+// 
+// Additional Comments: 
+//    This project is part of https://github.com/vicharak-in/shrike-lite.
+//    All logic gate examples (AND, OR, NOT, NAND, NOR, XOR) are
+//    available under the same structure. 
+// License: 
+//    Open Source — MIT License
+//    Copyright © 2025 Vicharak Computers Pvt. Ltd
+//-----------------------------------------------------------------------------
+
+(* top *) module not_gate(
+  (* iopad_external_pin *) output LED,
+  (* iopad_external_pin *) output LED_en,
+  (* iopad_external_pin *) input in,    
+  );
+  
+  assign LED_en = 1'b1;
+  assign LED = !in;
+  
+endmodule

--- a/Projects/logic_gates/not/not.ffpga
+++ b/Projects/logic_gates/not/not.ffpga
@@ -1,0 +1,843 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GPDProject version="37" oldestCompatibleVersion="32" GPDVersion="6.48.001" lastChange="11 Nov 2025 16:40:23" projectChecksumState="1" projectChecksum="97c3b32f">
+    <generalProjectSettings/>
+    <chip family="04" type="06" friendlyName="FFPGA" partNumber="67" package="26">
+        <nvmData registerLenght="480">0 0 0 28 0 0 0 0 A5 A5 A5 A5 0 0 0 0 0 0 0 0 5A 5A 5A 5A 0 0 0 0 22 22 22 22 22 22 22 22 22 22 0 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</nvmData>
+        <checksum crc32="0x451C1D42" version="2"/>
+        <VDDItem id="0">
+            <item id="0" caption="VDD (PIN 22)">
+                <graphics pos="(1350.00,143.10)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <VDDItem id="1">
+            <item id="1" caption="VDDIO (PIN 21)">
+                <graphics pos="(1350.00,226.67)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <item id="2" caption="GND (PIN 12)">
+            <graphics pos="(1350.00,298.48)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="3" caption="FPGA">
+            <graphics pos="(0.00,0.00)" angle="0" flipping="0" hidden="0" tOrigin="(640.00,442.50)"/>
+        </item>
+        <item id="4" caption="GPIO0 (PIN 13)">
+            <graphics pos="(35.00,592.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="5" caption="GPIO1 (PIN 14)">
+            <graphics pos="(150.00,542.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="6" caption="GPIO2 (PIN 15)">
+            <graphics pos="(35.00,493.59)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="7" caption="GPIO3 (PIN 16)">
+            <graphics pos="(150.00,444.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="8" caption="GPIO4 (PIN 17)">
+            <graphics pos="(35.00,394.74)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="9" caption="GPIO5 (PIN 18)">
+            <graphics pos="(35.00,197.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="10" caption="GPIO6 (PIN 19)">
+            <graphics pos="(150.00,148.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="11" caption="GPIO7 (PIN 20)">
+            <graphics pos="(35.00,98.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="12" caption="GPIO8 (PIN 23)">
+            <graphics pos="(1094.00,49.99)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="13" caption="GPIO9 (PIN 24)">
+            <graphics pos="(1200.00,102.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="14" caption="GPIO10 (PIN 1)">
+            <graphics pos="(1094.00,154.03)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="15" caption="GPIO11 (PIN 2)">
+            <graphics pos="(1200.00,206.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="16" caption="GPIO12 (PIN 3)">
+            <graphics pos="(1094.00,258.20)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="17" caption="GPIO13 (PIN 4)">
+            <graphics pos="(1200.00,310.28)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="18" caption="GPIO14 (PIN 5)">
+            <graphics pos="(1094.00,397.09)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="19" caption="GPIO15 (PIN 6)">
+            <graphics pos="(1200.00,449.75)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="20" caption="GPIO18 (PIN 9/GrP0)">
+            <graphics pos="(1094.00,604.84)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="21" caption="GPIO17 (PIN 8/GrP1)">
+            <graphics pos="(1200.00,553.34)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="22" caption="GPIO16 (PIN 7/GrP2)">
+            <graphics pos="(1094.00,501.25)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="23" caption="nRST (PIN 11)">
+            <graphics pos="(1094.00,356.17)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="24" caption="nSLEEP (PIN 10)">
+            <graphics pos="(1200.00,374.22)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="25" caption="OSC">
+            <graphics pos="(150.00,64.53)" angle="0" flipping="0" hidden="0" tOrigin="(25.00,10.00)"/>
+        </item>
+        <item id="26" caption="Phase-Locked Loop">
+            <graphics pos="(149.73,246.87)" angle="180" flipping="0" hidden="0" tOrigin="(25.00,70.00)"/>
+        </item>
+        <item id="27" caption="BRAM">
+            <graphics pos="(616.77,701.83)" angle="90" flipping="0" hidden="0" tOrigin="(25.00,100.00)"/>
+        </item>
+        <item id="28" caption="FPGA Core">
+            <graphics pos="(340.90,49.43)" angle="0" flipping="0" hidden="0" tOrigin="(300.00,300.00)"/>
+        </item>
+        <wire output="79" input="65" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (236.00,80.00); (236.00,250.00); (220.00,250.00)</points>
+        </wire>
+        <wire output="2" input="66" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (226.00,510.00); (226.00,383.00); (220.00,383.00)</points>
+        </wire>
+        <wire output="83" input="85" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="0" wireText="NET0" wireState="0">
+            <points>(129.00,344.00); (116.00,344.00); (116.00,392.00); (308.00,392.00); (308.00,383.00); (320.00,383.00)</points>
+        </wire>
+        <wire output="84" input="86" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="1" wireText="NET1" wireState="0">
+            <points>(711.00,669.00); (711.00,756.00)</points>
+        </wire>
+        <wire output="85" input="87" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="2" wireText="NET2" wireState="0">
+            <points>(726.00,669.00); (726.00,756.00)</points>
+        </wire>
+        <wire output="86" input="88" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="3" wireText="NET3" wireState="0">
+            <points>(220.00,70.00); (320.00,70.00)</points>
+        </wire>
+        <wire output="79" input="38" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (314.00,80.00); (314.00,87.00); (320.00,87.00)</points>
+        </wire>
+        <wire output="39" input="63" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="5" wireText="NET5" wireState="0">
+            <points>(320.00,54.00); (116.00,54.00); (116.00,75.00); (129.00,75.00)</points>
+        </wire>
+        <wire output="20" input="62" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="6" wireText="NET6" wireState="0">
+            <points>(1177.00,384.00); (967.00,384.00); (967.00,385.00); (961.00,385.00)</points>
+        </wire>
+        <wire output="19" input="61" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="7" wireText="NET7" wireState="0">
+            <points>(1071.00,366.00); (967.00,366.00); (967.00,367.00); (961.00,367.00)</points>
+        </wire>
+        <wire output="82" input="41" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="8" wireText="NET8" wireState="0">
+            <points>(642.00,847.00); (642.00,853.00); (308.00,853.00); (308.00,645.00); (320.00,645.00)</points>
+        </wire>
+        <wire output="21" input="75" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="9" wireText="NET9" wireState="0">
+            <points>(557.00,669.00); (557.00,756.00)</points>
+        </wire>
+        <wire output="25" input="76" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="10" wireText="NET10" wireState="0">
+            <points>(618.00,669.00); (618.00,756.00)</points>
+        </wire>
+        <wire output="22" input="77" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="11" wireText="NET11" wireState="0">
+            <points>(573.00,669.00); (573.00,756.00)</points>
+        </wire>
+        <wire output="23" input="78" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="12" wireText="NET12" wireState="0">
+            <points>(588.00,669.00); (588.00,756.00)</points>
+        </wire>
+        <wire output="26" input="79" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="13" wireText="NET13" wireState="0">
+            <points>(634.00,669.00); (634.00,756.00)</points>
+        </wire>
+        <wire output="27" input="80" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="14" wireText="NET14" wireState="0">
+            <points>(649.00,669.00); (649.00,756.00)</points>
+        </wire>
+        <wire output="28" input="81" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="15" wireText="NET15" wireState="0">
+            <points>(664.00,669.00); (664.00,756.00)</points>
+        </wire>
+        <wire output="24" input="82" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="16" wireText="NET16" wireState="0">
+            <points>(603.00,669.00); (603.00,756.00)</points>
+        </wire>
+        <wire output="29" input="83" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="17" wireText="NET17" wireState="0">
+            <points>(680.00,669.00); (680.00,756.00)</points>
+        </wire>
+        <wire output="30" input="84" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="18" wireText="NET18" wireState="0">
+            <points>(695.00,669.00); (695.00,756.00)</points>
+        </wire>
+        <wire output="80" input="39" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="20" wireText="NET20" wireState="0">
+            <points>(129.00,289.00); (116.00,289.00); (116.00,240.00); (308.00,240.00); (308.00,251.00); (320.00,251.00)</points>
+        </wire>
+        <wire output="34" input="67" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="21" wireText="NET21" wireState="0">
+            <points>(320.00,333.00); (220.00,333.00)</points>
+        </wire>
+        <wire output="38" input="68" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="22" wireText="NET22" wireState="0">
+            <points>(320.00,267.00); (220.00,267.00)</points>
+        </wire>
+        <wire output="37" input="69" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="23" wireText="NET23" wireState="0">
+            <points>(320.00,284.00); (220.00,284.00)</points>
+        </wire>
+        <wire output="36" input="70" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="24" wireText="NET24" wireState="0">
+            <points>(320.00,300.00); (220.00,300.00)</points>
+        </wire>
+        <wire output="35" input="71" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="25" wireText="NET25" wireState="0">
+            <points>(320.00,317.00); (220.00,317.00)</points>
+        </wire>
+        <wire output="33" input="72" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="26" wireText="NET26" wireState="0">
+            <points>(320.00,350.00); (220.00,350.00)</points>
+        </wire>
+        <wire output="32" input="73" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="27" wireText="NET27" wireState="0">
+            <points>(320.00,366.00); (220.00,366.00)</points>
+        </wire>
+        <wire output="41" input="0" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="28" wireText="NET28" wireState="0">
+            <points>(320.00,597.00); (97.00,597.00)</points>
+        </wire>
+        <wire output="42" input="1" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="29" wireText="NET29" wireState="0">
+            <points>(320.00,547.00); (212.00,547.00)</points>
+        </wire>
+        <wire output="43" input="2" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="30" wireText="NET30" wireState="0">
+            <points>(320.00,498.00); (97.00,498.00)</points>
+        </wire>
+        <wire output="44" input="3" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="31" wireText="NET31" wireState="0">
+            <points>(320.00,449.00); (212.00,449.00)</points>
+        </wire>
+        <wire output="45" input="4" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="32" wireText="NET32" wireState="0">
+            <points>(320.00,399.00); (97.00,399.00)</points>
+        </wire>
+        <wire output="46" input="5" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="33" wireText="NET33" wireState="0">
+            <points>(320.00,202.00); (97.00,202.00)</points>
+        </wire>
+        <wire output="47" input="6" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="34" wireText="NET34" wireState="0">
+            <points>(320.00,153.00); (212.00,153.00)</points>
+        </wire>
+        <wire output="48" input="7" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="35" wireText="NET35" wireState="0">
+            <points>(320.00,103.00); (97.00,103.00)</points>
+        </wire>
+        <wire output="49" input="8" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="36" wireText="NET36" wireState="0">
+            <points>(961.00,55.00); (1071.00,55.00)</points>
+        </wire>
+        <wire output="50" input="9" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="37" wireText="NET37" wireState="0">
+            <points>(961.00,107.00); (1177.00,107.00)</points>
+        </wire>
+        <wire output="51" input="10" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="38" wireText="NET38" wireState="0">
+            <points>(961.00,159.00); (1071.00,159.00)</points>
+        </wire>
+        <wire output="52" input="11" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="39" wireText="NET39" wireState="0">
+            <points>(961.00,211.00); (1177.00,211.00)</points>
+        </wire>
+        <wire output="53" input="12" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="40" wireText="NET40" wireState="0">
+            <points>(961.00,263.00); (1071.00,263.00)</points>
+        </wire>
+        <wire output="54" input="13" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="41" wireText="NET41" wireState="0">
+            <points>(961.00,315.00); (1177.00,315.00)</points>
+        </wire>
+        <wire output="55" input="14" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="42" wireText="NET42" wireState="0">
+            <points>(961.00,402.00); (1071.00,402.00)</points>
+        </wire>
+        <wire output="56" input="15" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="43" wireText="NET43" wireState="0">
+            <points>(961.00,454.00); (1177.00,454.00)</points>
+        </wire>
+        <wire output="57" input="16" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="44" wireText="NET44" wireState="0">
+            <points>(961.00,610.00); (1071.00,610.00)</points>
+        </wire>
+        <wire output="58" input="17" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="45" wireText="NET45" wireState="0">
+            <points>(961.00,558.00); (1177.00,558.00)</points>
+        </wire>
+        <wire output="59" input="18" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="46" wireText="NET46" wireState="0">
+            <points>(961.00,506.00); (1071.00,506.00)</points>
+        </wire>
+        <wire output="60" input="19" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="47" wireText="NET47" wireState="0">
+            <points>(320.00,630.00); (108.00,630.00); (108.00,648.00); (54.00,648.00); (54.00,633.00)</points>
+        </wire>
+        <wire output="61" input="20" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="48" wireText="NET48" wireState="0">
+            <points>(320.00,580.00); (220.00,580.00); (220.00,588.00); (169.00,588.00); (169.00,582.00)</points>
+        </wire>
+        <wire output="62" input="21" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="49" wireText="NET49" wireState="0">
+            <points>(320.00,531.00); (108.00,531.00); (108.00,552.00); (54.00,552.00); (54.00,534.00)</points>
+        </wire>
+        <wire output="63" input="22" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="50" wireText="NET50" wireState="0">
+            <points>(320.00,482.00); (220.00,482.00); (220.00,490.00); (169.00,490.00); (169.00,484.00)</points>
+        </wire>
+        <wire output="64" input="23" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="51" wireText="NET51" wireState="0">
+            <points>(320.00,432.00); (108.00,432.00); (108.00,448.00); (54.00,448.00); (54.00,435.00)</points>
+        </wire>
+        <wire output="65" input="24" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="52" wireText="NET52" wireState="0">
+            <points>(320.00,235.00); (108.00,235.00); (108.00,248.00); (54.00,248.00); (54.00,237.00)</points>
+        </wire>
+        <wire output="66" input="25" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="53" wireText="NET53" wireState="0">
+            <points>(320.00,185.00); (220.00,185.00); (220.00,194.00); (169.00,194.00); (169.00,188.00)</points>
+        </wire>
+        <wire output="67" input="26" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="54" wireText="NET54" wireState="0">
+            <points>(320.00,136.00); (108.00,136.00); (108.00,152.00); (54.00,152.00); (54.00,139.00)</points>
+        </wire>
+        <wire output="68" input="27" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="55" wireText="NET55" wireState="0">
+            <points>(961.00,90.00); (1060.00,90.00); (1060.00,96.00); (1113.00,96.00); (1113.00,90.00)</points>
+        </wire>
+        <wire output="69" input="28" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="56" wireText="NET56" wireState="0">
+            <points>(961.00,142.00); (1172.00,142.00); (1172.00,160.00); (1219.00,160.00); (1219.00,142.00)</points>
+        </wire>
+        <wire output="70" input="29" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="57" wireText="NET57" wireState="0">
+            <points>(961.00,194.00); (1060.00,194.00); (1060.00,200.00); (1113.00,200.00); (1113.00,194.00)</points>
+        </wire>
+        <wire output="71" input="30" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="58" wireText="NET58" wireState="0">
+            <points>(961.00,246.00); (1172.00,246.00); (1172.00,264.00); (1219.00,264.00); (1219.00,246.00)</points>
+        </wire>
+        <wire output="72" input="31" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="59" wireText="NET59" wireState="0">
+            <points>(961.00,298.00); (1060.00,298.00); (1060.00,304.00); (1113.00,304.00); (1113.00,298.00)</points>
+        </wire>
+        <wire output="73" input="32" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="60" wireText="NET60" wireState="0">
+            <points>(961.00,350.00); (1172.00,350.00); (1172.00,356.00); (1219.00,356.00); (1219.00,350.00)</points>
+        </wire>
+        <wire output="74" input="33" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="61" wireText="NET61" wireState="0">
+            <points>(961.00,437.00); (1060.00,437.00); (1060.00,443.00); (1113.00,443.00); (1113.00,437.00)</points>
+        </wire>
+        <wire output="75" input="34" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="62" wireText="NET62" wireState="0">
+            <points>(961.00,489.00); (1172.00,489.00); (1172.00,504.00); (1219.00,504.00); (1219.00,490.00)</points>
+        </wire>
+        <wire output="76" input="35" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="63" wireText="NET63" wireState="0">
+            <points>(961.00,645.00); (1060.00,645.00); (1060.00,664.00); (1113.00,664.00); (1113.00,645.00)</points>
+        </wire>
+        <wire output="77" input="36" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="64" wireText="NET64" wireState="0">
+            <points>(961.00,593.00); (1172.00,593.00); (1172.00,608.00); (1219.00,608.00); (1219.00,593.00)</points>
+        </wire>
+        <wire output="78" input="37" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="65" wireText="NET65" wireState="0">
+            <points>(961.00,541.00); (1060.00,541.00); (1060.00,547.00); (1113.00,547.00); (1113.00,541.00)</points>
+        </wire>
+        <wire output="0" input="42" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="66" wireText="NET66" wireState="0">
+            <points>(97.00,609.00); (314.00,609.00); (314.00,613.00); (320.00,613.00)</points>
+        </wire>
+        <wire output="1" input="43" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="67" wireText="NET67" wireState="0">
+            <points>(212.00,558.00); (314.00,558.00); (314.00,564.00); (320.00,564.00)</points>
+        </wire>
+        <wire output="2" input="44" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (314.00,510.00); (314.00,514.00); (320.00,514.00)</points>
+        </wire>
+        <wire output="3" input="45" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="68" wireText="NET68" wireState="0">
+            <points>(212.00,460.00); (314.00,460.00); (314.00,465.00); (320.00,465.00)</points>
+        </wire>
+        <wire output="4" input="46" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="69" wireText="NET69" wireState="0">
+            <points>(97.00,411.00); (314.00,411.00); (314.00,416.00); (320.00,416.00)</points>
+        </wire>
+        <wire output="5" input="47" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="70" wireText="NET70" wireState="0">
+            <points>(97.00,213.00); (314.00,213.00); (314.00,218.00); (320.00,218.00)</points>
+        </wire>
+        <wire output="6" input="48" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="71" wireText="NET71" wireState="0">
+            <points>(212.00,164.00); (314.00,164.00); (314.00,169.00); (320.00,169.00)</points>
+        </wire>
+        <wire output="7" input="49" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="72" wireText="NET72" wireState="0">
+            <points>(97.00,115.00); (314.00,115.00); (314.00,120.00); (320.00,120.00)</points>
+        </wire>
+        <wire output="8" input="50" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="73" wireText="NET73" wireState="0">
+            <points>(1071.00,66.00); (967.00,66.00); (967.00,72.00); (961.00,72.00)</points>
+        </wire>
+        <wire output="9" input="51" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="74" wireText="NET74" wireState="0">
+            <points>(1177.00,118.00); (967.00,118.00); (967.00,124.00); (961.00,124.00)</points>
+        </wire>
+        <wire output="10" input="52" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="75" wireText="NET75" wireState="0">
+            <points>(1071.00,170.00); (967.00,170.00); (967.00,176.00); (961.00,176.00)</points>
+        </wire>
+        <wire output="11" input="53" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="76" wireText="NET76" wireState="0">
+            <points>(1177.00,222.00); (967.00,222.00); (967.00,228.00); (961.00,228.00)</points>
+        </wire>
+        <wire output="12" input="54" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="77" wireText="NET77" wireState="0">
+            <points>(1071.00,275.00); (967.00,275.00); (967.00,280.00); (961.00,280.00)</points>
+        </wire>
+        <wire output="13" input="55" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="78" wireText="NET78" wireState="0">
+            <points>(1177.00,327.00); (967.00,327.00); (967.00,333.00); (961.00,333.00)</points>
+        </wire>
+        <wire output="14" input="56" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="79" wireText="NET79" wireState="0">
+            <points>(1071.00,413.00); (967.00,413.00); (967.00,419.00); (961.00,419.00)</points>
+        </wire>
+        <wire output="15" input="57" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="80" wireText="NET80" wireState="0">
+            <points>(1177.00,466.00); (967.00,466.00); (967.00,471.00); (961.00,471.00)</points>
+        </wire>
+        <wire output="16" input="58" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="81" wireText="NET81" wireState="0">
+            <points>(1071.00,621.00); (967.00,621.00); (967.00,628.00); (961.00,628.00)</points>
+        </wire>
+        <wire output="17" input="59" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="82" wireText="NET82" wireState="0">
+            <points>(1177.00,570.00); (967.00,570.00); (967.00,576.00); (961.00,576.00)</points>
+        </wire>
+        <wire output="18" input="60" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="83" wireText="NET83" wireState="0">
+            <points>(1071.00,518.00); (967.00,518.00); (967.00,524.00); (961.00,524.00)</points>
+        </wire>
+    </chip>
+    <emulatorConfiguration version="4" oldestCompatibleVersion="4">
+        <settings>
+            <autoApply value="0"/>
+            <platformSelector id="-1"/>
+        </settings>
+        <platform id="0" friendlyName="GreenPAK DIP Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="1" friendlyName="GreenPAK Advanced Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="2" friendlyName="GreenPAK Pro Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="4" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="5" friendlyName="GreenPAK Advanced Development Platform w/ Logic Level Adapter #1">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="6" friendlyName="ForgeFPGA Deluxe Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="7" friendlyName="ForgeFPGA Evaluation Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="8" friendlyName="SLG51000 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="9" friendlyName="SLG51001 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="10" friendlyName="SLG51002 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="11" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="12" friendlyName="GreenPAK Lite Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="13" friendlyName="HVPAK Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="14" friendlyName="SLG47105V Training Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="15" friendlyName="Power GreenPAK Development Motherboard">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="16" friendlyName="ForgeFPGA Deluxe Development Platform Rev. 2.0">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="17" friendlyName="HVPAK SLG47125 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+    </emulatorConfiguration>
+    <fpga-data>
+        <!--Fpga project data-->
+        <project-data-version>5</project-data-version>
+        <oldestCompatibleVersion>3</oldestCompatibleVersion>
+        <settings>
+            <generateBitstream>
+                <MAX_CPU>16</MAX_CPU>
+                <additionalArguments></additionalArguments>
+                <clockConcurrentOptimization>true</clockConcurrentOptimization>
+                <highDensityIOPacking>false</highDensityIOPacking>
+                <highDensityPackingLogic>true</highDensityPackingLogic>
+                <maximumRoutingIterations>300</maximumRoutingIterations>
+                <placeAndTrialRoute>false</placeAndTrialRoute>
+                <placeAndTrialRouteIterationCount>20</placeAndTrialRouteIterationCount>
+            </generateBitstream>
+            <simulation>
+                <wavedumpOutputFormat>1</wavedumpOutputFormat>
+            </simulation>
+            <synthesize>
+                <additionalArguments></additionalArguments>
+                <flatten>true</flatten>
+                <keep>false</keep>
+                <noDSP>true</noDSP>
+                <useABC9>true</useABC9>
+            </synthesize>
+        </settings>
+        <openedTabs>
+            <openedTab>main.v</openedTab>
+            <openedTab>I/O Planner</openedTab>
+        </openedTabs>
+        <pipelineStagesStates>
+            <pipelineStageState>
+                <pipelineStage>0</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+            <pipelineStageState>
+                <pipelineStage>1</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+        </pipelineStagesStates>
+        <modules>
+            <scr>
+                <module filename="main.v"/>
+            </scr>
+            <lib/>
+            <sim/>
+            <netlists/>
+            <timing-constraints/>
+        </modules>
+        <io-spec-tool>
+            <records filter="16">
+                <record id="IOB_t[0:0]_xy[31:5]_in0">
+                    <port-name>in</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:6]_out0">
+                    <port-name>LED</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:6]_out1">
+                    <port-name>LED_en</port-name>
+                </record>
+            </records>
+        </io-spec-tool>
+        <macrocell-mode-data>
+            <scene-data>
+                <scene-width>32767</scene-width>
+                <scene-height>32767</scene-height>
+                <scene-snapToGrid>1</scene-snapToGrid>
+            </scene-data>
+            <macrocells-data>
+                <macrocell>
+                    <macrocell-id>18</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input18</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>-240</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>19</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>20</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input20</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>21</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>22</macrocell-id>
+                    <macrocell-type>4</macrocell-type>
+                    <macrocell-title>NOT Gate</macrocell-title>
+                    <macrocell-name>not22</macrocell-name>
+                    <macrocell-posx>-100</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>23</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>24</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>25</macrocell-id>
+                    <macrocell-type>8</macrocell-type>
+                    <macrocell-title>NAND Gate</macrocell-title>
+                    <macrocell-name>nand25</macrocell-name>
+                    <macrocell-posx>240</macrocell-posx>
+                    <macrocell-posy>-200</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>26</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                        <port>
+                            <port-id>27</port-id>
+                            <port-index>1</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>28</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>29</macrocell-id>
+                    <macrocell-type>3</macrocell-type>
+                    <macrocell-title>OUT</macrocell-title>
+                    <macrocell-name>output29</macrocell-name>
+                    <macrocell-posx>640</macrocell-posx>
+                    <macrocell-posy>-140</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>30</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports/>
+                </macrocell>
+            </macrocells-data>
+            <wires-data>
+                <wire>
+                    <wire-id>31</wire-id>
+                    <wire-start-port-id>19</wire-start-port-id>
+                    <wire-end-port-id>26</wire-end-port-id>
+                    <wire-name>wire31</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>32</wire-id>
+                    <wire-start-port-id>21</wire-start-port-id>
+                    <wire-end-port-id>23</wire-end-port-id>
+                    <wire-name>wire32</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>33</wire-id>
+                    <wire-start-port-id>24</wire-start-port-id>
+                    <wire-end-port-id>27</wire-end-port-id>
+                    <wire-name>wire33</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>34</wire-id>
+                    <wire-start-port-id>28</wire-start-port-id>
+                    <wire-end-port-id>30</wire-end-port-id>
+                    <wire-name>wire34</wire-name>
+                </wire>
+            </wires-data>
+        </macrocell-mode-data>
+        <!--Fpga project data END-->
+    </fpga-data>
+    <projectData>
+        <specs>
+            <lastModify lastModifyValue="11.11.2025 10:56:30"/>
+            <vddSpecs vddMin="1.05" vddTyp="1.1" vddMax="1.15"/>
+            <vdd2Specs vdd2Min="1.71" vdd2Typ="2.5" vdd2Max="3.3"/>
+            <tempSpecs tempMin="-40" tempTyp="25" tempMax="85"/>
+        </specs>
+        <projectDataFields>
+            <textLineDataField name="Customer Name" id="2" text=""/>
+            <textLineDataField name="Customer Project Name" id="3" text=""/>
+            <textLineDataField name="Customer Project Number" id="4" text=""/>
+            <textLineDataField name="Customer Version Number" id="5" text=""/>
+            <multiTextLineDataField>
+                <textLineDataField name="Notes" id="6" text=""/>
+            </multiTextLineDataField>
+        </projectDataFields>
+    </projectData>
+    <i2cTool>
+        <i2cDebugger version="1"/>
+        <i2cStepper version="1" rowCount="0"/>
+        <i2cRegsTable version="1" tabCount="0"/>
+    </i2cTool>
+<logicAnalyzer>
+    <metadata>
+        <autosavePreset>-1</autosavePreset>
+        <currentPreset>-1</currentPreset>
+        <version>3</version>
+    </metadata>
+    <presetList/>
+</logicAnalyzer>
+
+</GPDProject>

--- a/Projects/logic_gates/or/ffpga/src/main.v
+++ b/Projects/logic_gates/or/ffpga/src/main.v
@@ -1,0 +1,40 @@
+//-----------------------------------------------------------------------------
+// Company:         Vicharak Computers PVT LTD
+// Engineer:        Shashank Bhosagi <shashankbhosagi0121@gmail.com>
+// 
+// Create Date:     NOV 11, 2025
+// Design Name:     Basic Logic Gates
+// Module Name:     or_gate
+// Project:         Shrike-Lite Examples
+// Target Device:   Shrike-Lite (RP2040 + Renesas FPGA (SLG47910V))
+// Tool Versions:   Go Configure Software Hub v.6.48
+// 
+// Description: 
+//    Simple 2-input OR gate implementation for beginners exploring
+//    FPGA design using Verilog on the Shrike-Lite.
+// Dependencies: 
+// None
+//
+// Version:
+//    1.0 - 11/11/2025 - Initial release
+// 
+// Additional Comments: 
+//    This project is part of https://github.com/vicharak-in/shrike-lite.
+//    All logic gate examples (AND, OR, NOT, NAND, NOR, XOR) are
+//    available under the same structure. 
+// License: 
+//    Open Source — MIT License
+//    Copyright © 2025 Vicharak Computers Pvt. Ltd
+//-----------------------------------------------------------------------------
+
+(* top *) module or_gate(
+  (* iopad_external_pin *) output LED,
+  (* iopad_external_pin *) output LED_en,
+  (* iopad_external_pin *) input a,  
+  (* iopad_external_pin *) input b,  
+  );
+  
+  assign LED_en = 1'b1;
+  assign LED = a | b;
+  
+endmodule

--- a/Projects/logic_gates/or/or.ffpga
+++ b/Projects/logic_gates/or/or.ffpga
@@ -1,0 +1,846 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GPDProject version="37" oldestCompatibleVersion="32" GPDVersion="6.48.001" lastChange="11 Nov 2025 16:26:41" projectChecksumState="1" projectChecksum="476434a9">
+    <generalProjectSettings/>
+    <chip family="04" type="06" friendlyName="FFPGA" partNumber="67" package="26">
+        <nvmData registerLenght="480">0 0 0 28 0 0 0 0 A5 A5 A5 A5 0 0 0 0 0 0 0 0 5A 5A 5A 5A 0 0 0 0 22 22 22 22 22 22 22 22 22 22 0 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</nvmData>
+        <checksum crc32="0x451C1D42" version="2"/>
+        <VDDItem id="0">
+            <item id="0" caption="VDD (PIN 22)">
+                <graphics pos="(1350.00,143.10)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <VDDItem id="1">
+            <item id="1" caption="VDDIO (PIN 21)">
+                <graphics pos="(1350.00,226.67)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <item id="2" caption="GND (PIN 12)">
+            <graphics pos="(1350.00,298.48)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="3" caption="FPGA">
+            <graphics pos="(0.00,0.00)" angle="0" flipping="0" hidden="0" tOrigin="(640.00,442.50)"/>
+        </item>
+        <item id="4" caption="GPIO0 (PIN 13)">
+            <graphics pos="(35.00,592.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="5" caption="GPIO1 (PIN 14)">
+            <graphics pos="(150.00,542.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="6" caption="GPIO2 (PIN 15)">
+            <graphics pos="(35.00,493.59)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="7" caption="GPIO3 (PIN 16)">
+            <graphics pos="(150.00,444.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="8" caption="GPIO4 (PIN 17)">
+            <graphics pos="(35.00,394.74)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="9" caption="GPIO5 (PIN 18)">
+            <graphics pos="(35.00,197.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="10" caption="GPIO6 (PIN 19)">
+            <graphics pos="(150.00,148.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="11" caption="GPIO7 (PIN 20)">
+            <graphics pos="(35.00,98.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="12" caption="GPIO8 (PIN 23)">
+            <graphics pos="(1094.00,49.99)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="13" caption="GPIO9 (PIN 24)">
+            <graphics pos="(1200.00,102.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="14" caption="GPIO10 (PIN 1)">
+            <graphics pos="(1094.00,154.03)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="15" caption="GPIO11 (PIN 2)">
+            <graphics pos="(1200.00,206.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="16" caption="GPIO12 (PIN 3)">
+            <graphics pos="(1094.00,258.20)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="17" caption="GPIO13 (PIN 4)">
+            <graphics pos="(1200.00,310.28)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="18" caption="GPIO14 (PIN 5)">
+            <graphics pos="(1094.00,397.09)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="19" caption="GPIO15 (PIN 6)">
+            <graphics pos="(1200.00,449.75)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="20" caption="GPIO18 (PIN 9/GrP0)">
+            <graphics pos="(1094.00,604.84)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="21" caption="GPIO17 (PIN 8/GrP1)">
+            <graphics pos="(1200.00,553.34)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="22" caption="GPIO16 (PIN 7/GrP2)">
+            <graphics pos="(1094.00,501.25)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="23" caption="nRST (PIN 11)">
+            <graphics pos="(1094.00,356.17)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="24" caption="nSLEEP (PIN 10)">
+            <graphics pos="(1200.00,374.22)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="25" caption="OSC">
+            <graphics pos="(150.00,64.53)" angle="0" flipping="0" hidden="0" tOrigin="(25.00,10.00)"/>
+        </item>
+        <item id="26" caption="Phase-Locked Loop">
+            <graphics pos="(149.73,246.87)" angle="180" flipping="0" hidden="0" tOrigin="(25.00,70.00)"/>
+        </item>
+        <item id="27" caption="BRAM">
+            <graphics pos="(616.77,701.83)" angle="90" flipping="0" hidden="0" tOrigin="(25.00,100.00)"/>
+        </item>
+        <item id="28" caption="FPGA Core">
+            <graphics pos="(340.90,49.43)" angle="0" flipping="0" hidden="0" tOrigin="(300.00,300.00)"/>
+        </item>
+        <wire output="79" input="65" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (236.00,80.00); (236.00,250.00); (220.00,250.00)</points>
+        </wire>
+        <wire output="2" input="66" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (226.00,510.00); (226.00,383.00); (220.00,383.00)</points>
+        </wire>
+        <wire output="83" input="85" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="0" wireText="NET0" wireState="0">
+            <points>(129.00,344.00); (116.00,344.00); (116.00,392.00); (308.00,392.00); (308.00,383.00); (320.00,383.00)</points>
+        </wire>
+        <wire output="84" input="86" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="1" wireText="NET1" wireState="0">
+            <points>(711.00,669.00); (711.00,756.00)</points>
+        </wire>
+        <wire output="85" input="87" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="2" wireText="NET2" wireState="0">
+            <points>(726.00,669.00); (726.00,756.00)</points>
+        </wire>
+        <wire output="86" input="88" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="3" wireText="NET3" wireState="0">
+            <points>(220.00,70.00); (320.00,70.00)</points>
+        </wire>
+        <wire output="79" input="38" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (314.00,80.00); (314.00,87.00); (320.00,87.00)</points>
+        </wire>
+        <wire output="39" input="63" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="5" wireText="NET5" wireState="0">
+            <points>(320.00,54.00); (116.00,54.00); (116.00,75.00); (129.00,75.00)</points>
+        </wire>
+        <wire output="20" input="62" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="6" wireText="NET6" wireState="0">
+            <points>(1177.00,384.00); (967.00,384.00); (967.00,385.00); (961.00,385.00)</points>
+        </wire>
+        <wire output="19" input="61" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="7" wireText="NET7" wireState="0">
+            <points>(1071.00,366.00); (967.00,366.00); (967.00,367.00); (961.00,367.00)</points>
+        </wire>
+        <wire output="82" input="41" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="8" wireText="NET8" wireState="0">
+            <points>(642.00,847.00); (642.00,853.00); (308.00,853.00); (308.00,645.00); (320.00,645.00)</points>
+        </wire>
+        <wire output="21" input="75" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="9" wireText="NET9" wireState="0">
+            <points>(557.00,669.00); (557.00,756.00)</points>
+        </wire>
+        <wire output="25" input="76" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="10" wireText="NET10" wireState="0">
+            <points>(618.00,669.00); (618.00,756.00)</points>
+        </wire>
+        <wire output="22" input="77" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="11" wireText="NET11" wireState="0">
+            <points>(573.00,669.00); (573.00,756.00)</points>
+        </wire>
+        <wire output="23" input="78" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="12" wireText="NET12" wireState="0">
+            <points>(588.00,669.00); (588.00,756.00)</points>
+        </wire>
+        <wire output="26" input="79" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="13" wireText="NET13" wireState="0">
+            <points>(634.00,669.00); (634.00,756.00)</points>
+        </wire>
+        <wire output="27" input="80" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="14" wireText="NET14" wireState="0">
+            <points>(649.00,669.00); (649.00,756.00)</points>
+        </wire>
+        <wire output="28" input="81" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="15" wireText="NET15" wireState="0">
+            <points>(664.00,669.00); (664.00,756.00)</points>
+        </wire>
+        <wire output="24" input="82" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="16" wireText="NET16" wireState="0">
+            <points>(603.00,669.00); (603.00,756.00)</points>
+        </wire>
+        <wire output="29" input="83" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="17" wireText="NET17" wireState="0">
+            <points>(680.00,669.00); (680.00,756.00)</points>
+        </wire>
+        <wire output="30" input="84" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="18" wireText="NET18" wireState="0">
+            <points>(695.00,669.00); (695.00,756.00)</points>
+        </wire>
+        <wire output="80" input="39" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="20" wireText="NET20" wireState="0">
+            <points>(129.00,289.00); (116.00,289.00); (116.00,240.00); (308.00,240.00); (308.00,251.00); (320.00,251.00)</points>
+        </wire>
+        <wire output="34" input="67" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="21" wireText="NET21" wireState="0">
+            <points>(320.00,333.00); (220.00,333.00)</points>
+        </wire>
+        <wire output="38" input="68" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="22" wireText="NET22" wireState="0">
+            <points>(320.00,267.00); (220.00,267.00)</points>
+        </wire>
+        <wire output="37" input="69" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="23" wireText="NET23" wireState="0">
+            <points>(320.00,284.00); (220.00,284.00)</points>
+        </wire>
+        <wire output="36" input="70" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="24" wireText="NET24" wireState="0">
+            <points>(320.00,300.00); (220.00,300.00)</points>
+        </wire>
+        <wire output="35" input="71" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="25" wireText="NET25" wireState="0">
+            <points>(320.00,317.00); (220.00,317.00)</points>
+        </wire>
+        <wire output="33" input="72" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="26" wireText="NET26" wireState="0">
+            <points>(320.00,350.00); (220.00,350.00)</points>
+        </wire>
+        <wire output="32" input="73" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="27" wireText="NET27" wireState="0">
+            <points>(320.00,366.00); (220.00,366.00)</points>
+        </wire>
+        <wire output="41" input="0" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="28" wireText="NET28" wireState="0">
+            <points>(320.00,597.00); (97.00,597.00)</points>
+        </wire>
+        <wire output="42" input="1" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="29" wireText="NET29" wireState="0">
+            <points>(320.00,547.00); (212.00,547.00)</points>
+        </wire>
+        <wire output="43" input="2" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="30" wireText="NET30" wireState="0">
+            <points>(320.00,498.00); (97.00,498.00)</points>
+        </wire>
+        <wire output="44" input="3" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="31" wireText="NET31" wireState="0">
+            <points>(320.00,449.00); (212.00,449.00)</points>
+        </wire>
+        <wire output="45" input="4" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="32" wireText="NET32" wireState="0">
+            <points>(320.00,399.00); (97.00,399.00)</points>
+        </wire>
+        <wire output="46" input="5" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="33" wireText="NET33" wireState="0">
+            <points>(320.00,202.00); (97.00,202.00)</points>
+        </wire>
+        <wire output="47" input="6" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="34" wireText="NET34" wireState="0">
+            <points>(320.00,153.00); (212.00,153.00)</points>
+        </wire>
+        <wire output="48" input="7" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="35" wireText="NET35" wireState="0">
+            <points>(320.00,103.00); (97.00,103.00)</points>
+        </wire>
+        <wire output="49" input="8" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="36" wireText="NET36" wireState="0">
+            <points>(961.00,55.00); (1071.00,55.00)</points>
+        </wire>
+        <wire output="50" input="9" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="37" wireText="NET37" wireState="0">
+            <points>(961.00,107.00); (1177.00,107.00)</points>
+        </wire>
+        <wire output="51" input="10" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="38" wireText="NET38" wireState="0">
+            <points>(961.00,159.00); (1071.00,159.00)</points>
+        </wire>
+        <wire output="52" input="11" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="39" wireText="NET39" wireState="0">
+            <points>(961.00,211.00); (1177.00,211.00)</points>
+        </wire>
+        <wire output="53" input="12" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="40" wireText="NET40" wireState="0">
+            <points>(961.00,263.00); (1071.00,263.00)</points>
+        </wire>
+        <wire output="54" input="13" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="41" wireText="NET41" wireState="0">
+            <points>(961.00,315.00); (1177.00,315.00)</points>
+        </wire>
+        <wire output="55" input="14" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="42" wireText="NET42" wireState="0">
+            <points>(961.00,402.00); (1071.00,402.00)</points>
+        </wire>
+        <wire output="56" input="15" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="43" wireText="NET43" wireState="0">
+            <points>(961.00,454.00); (1177.00,454.00)</points>
+        </wire>
+        <wire output="57" input="16" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="44" wireText="NET44" wireState="0">
+            <points>(961.00,610.00); (1071.00,610.00)</points>
+        </wire>
+        <wire output="58" input="17" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="45" wireText="NET45" wireState="0">
+            <points>(961.00,558.00); (1177.00,558.00)</points>
+        </wire>
+        <wire output="59" input="18" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="46" wireText="NET46" wireState="0">
+            <points>(961.00,506.00); (1071.00,506.00)</points>
+        </wire>
+        <wire output="60" input="19" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="47" wireText="NET47" wireState="0">
+            <points>(320.00,630.00); (108.00,630.00); (108.00,648.00); (54.00,648.00); (54.00,633.00)</points>
+        </wire>
+        <wire output="61" input="20" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="48" wireText="NET48" wireState="0">
+            <points>(320.00,580.00); (220.00,580.00); (220.00,588.00); (169.00,588.00); (169.00,582.00)</points>
+        </wire>
+        <wire output="62" input="21" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="49" wireText="NET49" wireState="0">
+            <points>(320.00,531.00); (108.00,531.00); (108.00,552.00); (54.00,552.00); (54.00,534.00)</points>
+        </wire>
+        <wire output="63" input="22" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="50" wireText="NET50" wireState="0">
+            <points>(320.00,482.00); (220.00,482.00); (220.00,490.00); (169.00,490.00); (169.00,484.00)</points>
+        </wire>
+        <wire output="64" input="23" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="51" wireText="NET51" wireState="0">
+            <points>(320.00,432.00); (108.00,432.00); (108.00,448.00); (54.00,448.00); (54.00,435.00)</points>
+        </wire>
+        <wire output="65" input="24" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="52" wireText="NET52" wireState="0">
+            <points>(320.00,235.00); (108.00,235.00); (108.00,248.00); (54.00,248.00); (54.00,237.00)</points>
+        </wire>
+        <wire output="66" input="25" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="53" wireText="NET53" wireState="0">
+            <points>(320.00,185.00); (220.00,185.00); (220.00,194.00); (169.00,194.00); (169.00,188.00)</points>
+        </wire>
+        <wire output="67" input="26" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="54" wireText="NET54" wireState="0">
+            <points>(320.00,136.00); (108.00,136.00); (108.00,152.00); (54.00,152.00); (54.00,139.00)</points>
+        </wire>
+        <wire output="68" input="27" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="55" wireText="NET55" wireState="0">
+            <points>(961.00,90.00); (1060.00,90.00); (1060.00,96.00); (1113.00,96.00); (1113.00,90.00)</points>
+        </wire>
+        <wire output="69" input="28" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="56" wireText="NET56" wireState="0">
+            <points>(961.00,142.00); (1172.00,142.00); (1172.00,160.00); (1219.00,160.00); (1219.00,142.00)</points>
+        </wire>
+        <wire output="70" input="29" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="57" wireText="NET57" wireState="0">
+            <points>(961.00,194.00); (1060.00,194.00); (1060.00,200.00); (1113.00,200.00); (1113.00,194.00)</points>
+        </wire>
+        <wire output="71" input="30" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="58" wireText="NET58" wireState="0">
+            <points>(961.00,246.00); (1172.00,246.00); (1172.00,264.00); (1219.00,264.00); (1219.00,246.00)</points>
+        </wire>
+        <wire output="72" input="31" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="59" wireText="NET59" wireState="0">
+            <points>(961.00,298.00); (1060.00,298.00); (1060.00,304.00); (1113.00,304.00); (1113.00,298.00)</points>
+        </wire>
+        <wire output="73" input="32" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="60" wireText="NET60" wireState="0">
+            <points>(961.00,350.00); (1172.00,350.00); (1172.00,356.00); (1219.00,356.00); (1219.00,350.00)</points>
+        </wire>
+        <wire output="74" input="33" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="61" wireText="NET61" wireState="0">
+            <points>(961.00,437.00); (1060.00,437.00); (1060.00,443.00); (1113.00,443.00); (1113.00,437.00)</points>
+        </wire>
+        <wire output="75" input="34" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="62" wireText="NET62" wireState="0">
+            <points>(961.00,489.00); (1172.00,489.00); (1172.00,504.00); (1219.00,504.00); (1219.00,490.00)</points>
+        </wire>
+        <wire output="76" input="35" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="63" wireText="NET63" wireState="0">
+            <points>(961.00,645.00); (1060.00,645.00); (1060.00,664.00); (1113.00,664.00); (1113.00,645.00)</points>
+        </wire>
+        <wire output="77" input="36" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="64" wireText="NET64" wireState="0">
+            <points>(961.00,593.00); (1172.00,593.00); (1172.00,608.00); (1219.00,608.00); (1219.00,593.00)</points>
+        </wire>
+        <wire output="78" input="37" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="65" wireText="NET65" wireState="0">
+            <points>(961.00,541.00); (1060.00,541.00); (1060.00,547.00); (1113.00,547.00); (1113.00,541.00)</points>
+        </wire>
+        <wire output="0" input="42" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="66" wireText="NET66" wireState="0">
+            <points>(97.00,609.00); (314.00,609.00); (314.00,613.00); (320.00,613.00)</points>
+        </wire>
+        <wire output="1" input="43" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="67" wireText="NET67" wireState="0">
+            <points>(212.00,558.00); (314.00,558.00); (314.00,564.00); (320.00,564.00)</points>
+        </wire>
+        <wire output="2" input="44" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (314.00,510.00); (314.00,514.00); (320.00,514.00)</points>
+        </wire>
+        <wire output="3" input="45" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="68" wireText="NET68" wireState="0">
+            <points>(212.00,460.00); (314.00,460.00); (314.00,465.00); (320.00,465.00)</points>
+        </wire>
+        <wire output="4" input="46" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="69" wireText="NET69" wireState="0">
+            <points>(97.00,411.00); (314.00,411.00); (314.00,416.00); (320.00,416.00)</points>
+        </wire>
+        <wire output="5" input="47" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="70" wireText="NET70" wireState="0">
+            <points>(97.00,213.00); (314.00,213.00); (314.00,218.00); (320.00,218.00)</points>
+        </wire>
+        <wire output="6" input="48" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="71" wireText="NET71" wireState="0">
+            <points>(212.00,164.00); (314.00,164.00); (314.00,169.00); (320.00,169.00)</points>
+        </wire>
+        <wire output="7" input="49" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="72" wireText="NET72" wireState="0">
+            <points>(97.00,115.00); (314.00,115.00); (314.00,120.00); (320.00,120.00)</points>
+        </wire>
+        <wire output="8" input="50" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="73" wireText="NET73" wireState="0">
+            <points>(1071.00,66.00); (967.00,66.00); (967.00,72.00); (961.00,72.00)</points>
+        </wire>
+        <wire output="9" input="51" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="74" wireText="NET74" wireState="0">
+            <points>(1177.00,118.00); (967.00,118.00); (967.00,124.00); (961.00,124.00)</points>
+        </wire>
+        <wire output="10" input="52" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="75" wireText="NET75" wireState="0">
+            <points>(1071.00,170.00); (967.00,170.00); (967.00,176.00); (961.00,176.00)</points>
+        </wire>
+        <wire output="11" input="53" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="76" wireText="NET76" wireState="0">
+            <points>(1177.00,222.00); (967.00,222.00); (967.00,228.00); (961.00,228.00)</points>
+        </wire>
+        <wire output="12" input="54" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="77" wireText="NET77" wireState="0">
+            <points>(1071.00,275.00); (967.00,275.00); (967.00,280.00); (961.00,280.00)</points>
+        </wire>
+        <wire output="13" input="55" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="78" wireText="NET78" wireState="0">
+            <points>(1177.00,327.00); (967.00,327.00); (967.00,333.00); (961.00,333.00)</points>
+        </wire>
+        <wire output="14" input="56" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="79" wireText="NET79" wireState="0">
+            <points>(1071.00,413.00); (967.00,413.00); (967.00,419.00); (961.00,419.00)</points>
+        </wire>
+        <wire output="15" input="57" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="80" wireText="NET80" wireState="0">
+            <points>(1177.00,466.00); (967.00,466.00); (967.00,471.00); (961.00,471.00)</points>
+        </wire>
+        <wire output="16" input="58" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="81" wireText="NET81" wireState="0">
+            <points>(1071.00,621.00); (967.00,621.00); (967.00,628.00); (961.00,628.00)</points>
+        </wire>
+        <wire output="17" input="59" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="82" wireText="NET82" wireState="0">
+            <points>(1177.00,570.00); (967.00,570.00); (967.00,576.00); (961.00,576.00)</points>
+        </wire>
+        <wire output="18" input="60" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="83" wireText="NET83" wireState="0">
+            <points>(1071.00,518.00); (967.00,518.00); (967.00,524.00); (961.00,524.00)</points>
+        </wire>
+    </chip>
+    <emulatorConfiguration version="4" oldestCompatibleVersion="4">
+        <settings>
+            <autoApply value="0"/>
+            <platformSelector id="-1"/>
+        </settings>
+        <platform id="0" friendlyName="GreenPAK DIP Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="1" friendlyName="GreenPAK Advanced Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="2" friendlyName="GreenPAK Pro Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="4" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="5" friendlyName="GreenPAK Advanced Development Platform w/ Logic Level Adapter #1">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="6" friendlyName="ForgeFPGA Deluxe Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="7" friendlyName="ForgeFPGA Evaluation Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="8" friendlyName="SLG51000 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="9" friendlyName="SLG51001 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="10" friendlyName="SLG51002 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="11" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="12" friendlyName="GreenPAK Lite Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="13" friendlyName="HVPAK Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="14" friendlyName="SLG47105V Training Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="15" friendlyName="Power GreenPAK Development Motherboard">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="16" friendlyName="ForgeFPGA Deluxe Development Platform Rev. 2.0">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="17" friendlyName="HVPAK SLG47125 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+    </emulatorConfiguration>
+    <fpga-data>
+        <!--Fpga project data-->
+        <project-data-version>5</project-data-version>
+        <oldestCompatibleVersion>3</oldestCompatibleVersion>
+        <settings>
+            <generateBitstream>
+                <MAX_CPU>16</MAX_CPU>
+                <additionalArguments></additionalArguments>
+                <clockConcurrentOptimization>true</clockConcurrentOptimization>
+                <highDensityIOPacking>false</highDensityIOPacking>
+                <highDensityPackingLogic>true</highDensityPackingLogic>
+                <maximumRoutingIterations>300</maximumRoutingIterations>
+                <placeAndTrialRoute>false</placeAndTrialRoute>
+                <placeAndTrialRouteIterationCount>20</placeAndTrialRouteIterationCount>
+            </generateBitstream>
+            <simulation>
+                <wavedumpOutputFormat>1</wavedumpOutputFormat>
+            </simulation>
+            <synthesize>
+                <additionalArguments></additionalArguments>
+                <flatten>true</flatten>
+                <keep>false</keep>
+                <noDSP>true</noDSP>
+                <useABC9>true</useABC9>
+            </synthesize>
+        </settings>
+        <openedTabs>
+            <openedTab>main.v</openedTab>
+            <openedTab>I/O Planner</openedTab>
+        </openedTabs>
+        <pipelineStagesStates>
+            <pipelineStageState>
+                <pipelineStage>0</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+            <pipelineStageState>
+                <pipelineStage>1</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+        </pipelineStagesStates>
+        <modules>
+            <scr>
+                <module filename="main.v"/>
+            </scr>
+            <lib/>
+            <sim/>
+            <netlists/>
+            <timing-constraints/>
+        </modules>
+        <io-spec-tool>
+            <records filter="16">
+                <record id="IOB_t[0:0]_xy[31:4]_in0">
+                    <port-name>b</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:5]_in0">
+                    <port-name>a</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:6]_out0">
+                    <port-name>LED</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:6]_out1">
+                    <port-name>LED_en</port-name>
+                </record>
+            </records>
+        </io-spec-tool>
+        <macrocell-mode-data>
+            <scene-data>
+                <scene-width>32767</scene-width>
+                <scene-height>32767</scene-height>
+                <scene-snapToGrid>1</scene-snapToGrid>
+            </scene-data>
+            <macrocells-data>
+                <macrocell>
+                    <macrocell-id>18</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input18</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>-240</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>19</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>20</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input20</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>21</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>22</macrocell-id>
+                    <macrocell-type>4</macrocell-type>
+                    <macrocell-title>NOT Gate</macrocell-title>
+                    <macrocell-name>not22</macrocell-name>
+                    <macrocell-posx>-100</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>23</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>24</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>25</macrocell-id>
+                    <macrocell-type>8</macrocell-type>
+                    <macrocell-title>NAND Gate</macrocell-title>
+                    <macrocell-name>nand25</macrocell-name>
+                    <macrocell-posx>240</macrocell-posx>
+                    <macrocell-posy>-200</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>26</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                        <port>
+                            <port-id>27</port-id>
+                            <port-index>1</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>28</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>29</macrocell-id>
+                    <macrocell-type>3</macrocell-type>
+                    <macrocell-title>OUT</macrocell-title>
+                    <macrocell-name>output29</macrocell-name>
+                    <macrocell-posx>640</macrocell-posx>
+                    <macrocell-posy>-140</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>30</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports/>
+                </macrocell>
+            </macrocells-data>
+            <wires-data>
+                <wire>
+                    <wire-id>31</wire-id>
+                    <wire-start-port-id>19</wire-start-port-id>
+                    <wire-end-port-id>26</wire-end-port-id>
+                    <wire-name>wire31</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>32</wire-id>
+                    <wire-start-port-id>21</wire-start-port-id>
+                    <wire-end-port-id>23</wire-end-port-id>
+                    <wire-name>wire32</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>33</wire-id>
+                    <wire-start-port-id>24</wire-start-port-id>
+                    <wire-end-port-id>27</wire-end-port-id>
+                    <wire-name>wire33</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>34</wire-id>
+                    <wire-start-port-id>28</wire-start-port-id>
+                    <wire-end-port-id>30</wire-end-port-id>
+                    <wire-name>wire34</wire-name>
+                </wire>
+            </wires-data>
+        </macrocell-mode-data>
+        <!--Fpga project data END-->
+    </fpga-data>
+    <projectData>
+        <specs>
+            <lastModify lastModifyValue="11.11.2025 10:48:15"/>
+            <vddSpecs vddMin="1.05" vddTyp="1.1" vddMax="1.15"/>
+            <vdd2Specs vdd2Min="1.71" vdd2Typ="2.5" vdd2Max="3.3"/>
+            <tempSpecs tempMin="-40" tempTyp="25" tempMax="85"/>
+        </specs>
+        <projectDataFields>
+            <textLineDataField name="Customer Name" id="2" text=""/>
+            <textLineDataField name="Customer Project Name" id="3" text=""/>
+            <textLineDataField name="Customer Project Number" id="4" text=""/>
+            <textLineDataField name="Customer Version Number" id="5" text=""/>
+            <multiTextLineDataField>
+                <textLineDataField name="Notes" id="6" text=""/>
+            </multiTextLineDataField>
+        </projectDataFields>
+    </projectData>
+    <i2cTool>
+        <i2cDebugger version="1"/>
+        <i2cStepper version="1" rowCount="0"/>
+        <i2cRegsTable version="1" tabCount="0"/>
+    </i2cTool>
+<logicAnalyzer>
+    <metadata>
+        <autosavePreset>-1</autosavePreset>
+        <currentPreset>-1</currentPreset>
+        <version>3</version>
+    </metadata>
+    <presetList/>
+</logicAnalyzer>
+
+</GPDProject>

--- a/Projects/logic_gates/xor/ffpga/src/main.v
+++ b/Projects/logic_gates/xor/ffpga/src/main.v
@@ -1,0 +1,40 @@
+//-----------------------------------------------------------------------------
+// Company:         Vicharak Computers PVT LTD
+// Engineer:        Shashank Bhosagi <shashankbhosagi0121@gmail.com>
+// 
+// Create Date:     NOV 11, 2025
+// Design Name:     Basic Logic Gates
+// Module Name:     xor_gate
+// Project:         Shrike-Lite Examples
+// Target Device:   Shrike-Lite (RP2040 + Renesas FPGA (SLG47910V))
+// Tool Versions:   Go Configure Software Hub v.6.48
+// 
+// Description: 
+//    Simple 2-input XOR gate implementation for beginners exploring
+//    FPGA design using Verilog on the Shrike-Lite.
+// Dependencies: 
+// None
+//
+// Version:
+//    1.0 - 11/11/2025 - Initial release
+// 
+// Additional Comments: 
+//    This project is part of https://github.com/vicharak-in/shrike-lite.
+//    All logic gate examples (AND, OR, NOT, NAND, NOR, XOR) are
+//    available under the same structure. 
+// License: 
+//    Open Source — MIT License
+//    Copyright © 2025 Vicharak Computers Pvt. Ltd
+//-----------------------------------------------------------------------------
+
+(* top *) module xor_gate(
+  (* iopad_external_pin *) output LED,
+  (* iopad_external_pin *) output LED_en,
+  (* iopad_external_pin *) input a,  
+  (* iopad_external_pin *) input b
+  );
+  
+  assign LED_en = 1'b1;
+  assign LED = a ^ b;
+  
+endmodule

--- a/Projects/logic_gates/xor/xor.ffpga
+++ b/Projects/logic_gates/xor/xor.ffpga
@@ -1,0 +1,846 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GPDProject version="37" oldestCompatibleVersion="32" GPDVersion="6.48.001" lastChange="11 Nov 2025 17:27:11" projectChecksumState="1" projectChecksum="a0033b96">
+    <generalProjectSettings/>
+    <chip family="04" type="06" friendlyName="FFPGA" partNumber="67" package="26">
+        <nvmData registerLenght="480">0 0 0 28 0 0 0 0 A5 A5 A5 A5 0 0 0 0 0 0 0 0 5A 5A 5A 5A 0 0 0 0 22 22 22 22 22 22 22 22 22 22 0 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</nvmData>
+        <checksum crc32="0x451C1D42" version="2"/>
+        <VDDItem id="0">
+            <item id="0" caption="VDD (PIN 22)">
+                <graphics pos="(1350.00,143.10)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <VDDItem id="1">
+            <item id="1" caption="VDDIO (PIN 21)">
+                <graphics pos="(1350.00,226.67)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <item id="2" caption="GND (PIN 12)">
+            <graphics pos="(1350.00,298.48)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="3" caption="FPGA">
+            <graphics pos="(0.00,0.00)" angle="0" flipping="0" hidden="0" tOrigin="(640.00,442.50)"/>
+        </item>
+        <item id="4" caption="GPIO0 (PIN 13)">
+            <graphics pos="(35.00,592.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="5" caption="GPIO1 (PIN 14)">
+            <graphics pos="(150.00,542.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="6" caption="GPIO2 (PIN 15)">
+            <graphics pos="(35.00,493.59)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="7" caption="GPIO3 (PIN 16)">
+            <graphics pos="(150.00,444.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="8" caption="GPIO4 (PIN 17)">
+            <graphics pos="(35.00,394.74)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="9" caption="GPIO5 (PIN 18)">
+            <graphics pos="(35.00,197.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="10" caption="GPIO6 (PIN 19)">
+            <graphics pos="(150.00,148.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="11" caption="GPIO7 (PIN 20)">
+            <graphics pos="(35.00,98.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="12" caption="GPIO8 (PIN 23)">
+            <graphics pos="(1094.00,49.99)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="13" caption="GPIO9 (PIN 24)">
+            <graphics pos="(1200.00,102.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="14" caption="GPIO10 (PIN 1)">
+            <graphics pos="(1094.00,154.03)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="15" caption="GPIO11 (PIN 2)">
+            <graphics pos="(1200.00,206.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="16" caption="GPIO12 (PIN 3)">
+            <graphics pos="(1094.00,258.20)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="17" caption="GPIO13 (PIN 4)">
+            <graphics pos="(1200.00,310.28)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="18" caption="GPIO14 (PIN 5)">
+            <graphics pos="(1094.00,397.09)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="19" caption="GPIO15 (PIN 6)">
+            <graphics pos="(1200.00,449.75)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="20" caption="GPIO18 (PIN 9/GrP0)">
+            <graphics pos="(1094.00,604.84)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="21" caption="GPIO17 (PIN 8/GrP1)">
+            <graphics pos="(1200.00,553.34)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="22" caption="GPIO16 (PIN 7/GrP2)">
+            <graphics pos="(1094.00,501.25)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="23" caption="nRST (PIN 11)">
+            <graphics pos="(1094.00,356.17)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="24" caption="nSLEEP (PIN 10)">
+            <graphics pos="(1200.00,374.22)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="25" caption="OSC">
+            <graphics pos="(150.00,64.53)" angle="0" flipping="0" hidden="0" tOrigin="(25.00,10.00)"/>
+        </item>
+        <item id="26" caption="Phase-Locked Loop">
+            <graphics pos="(149.73,246.87)" angle="180" flipping="0" hidden="0" tOrigin="(25.00,70.00)"/>
+        </item>
+        <item id="27" caption="BRAM">
+            <graphics pos="(616.77,701.83)" angle="90" flipping="0" hidden="0" tOrigin="(25.00,100.00)"/>
+        </item>
+        <item id="28" caption="FPGA Core">
+            <graphics pos="(340.90,49.43)" angle="0" flipping="0" hidden="0" tOrigin="(300.00,300.00)"/>
+        </item>
+        <wire output="79" input="65" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (236.00,80.00); (236.00,250.00); (220.00,250.00)</points>
+        </wire>
+        <wire output="2" input="66" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (226.00,510.00); (226.00,383.00); (220.00,383.00)</points>
+        </wire>
+        <wire output="83" input="85" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="0" wireText="NET0" wireState="0">
+            <points>(129.00,344.00); (116.00,344.00); (116.00,392.00); (308.00,392.00); (308.00,383.00); (320.00,383.00)</points>
+        </wire>
+        <wire output="84" input="86" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="1" wireText="NET1" wireState="0">
+            <points>(711.00,669.00); (711.00,756.00)</points>
+        </wire>
+        <wire output="85" input="87" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="2" wireText="NET2" wireState="0">
+            <points>(726.00,669.00); (726.00,756.00)</points>
+        </wire>
+        <wire output="86" input="88" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="3" wireText="NET3" wireState="0">
+            <points>(220.00,70.00); (320.00,70.00)</points>
+        </wire>
+        <wire output="79" input="38" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (314.00,80.00); (314.00,87.00); (320.00,87.00)</points>
+        </wire>
+        <wire output="39" input="63" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="5" wireText="NET5" wireState="0">
+            <points>(320.00,54.00); (116.00,54.00); (116.00,75.00); (129.00,75.00)</points>
+        </wire>
+        <wire output="20" input="62" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="6" wireText="NET6" wireState="0">
+            <points>(1177.00,384.00); (967.00,384.00); (967.00,385.00); (961.00,385.00)</points>
+        </wire>
+        <wire output="19" input="61" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="7" wireText="NET7" wireState="0">
+            <points>(1071.00,366.00); (967.00,366.00); (967.00,367.00); (961.00,367.00)</points>
+        </wire>
+        <wire output="82" input="41" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="8" wireText="NET8" wireState="0">
+            <points>(642.00,847.00); (642.00,853.00); (308.00,853.00); (308.00,645.00); (320.00,645.00)</points>
+        </wire>
+        <wire output="21" input="75" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="9" wireText="NET9" wireState="0">
+            <points>(557.00,669.00); (557.00,756.00)</points>
+        </wire>
+        <wire output="25" input="76" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="10" wireText="NET10" wireState="0">
+            <points>(618.00,669.00); (618.00,756.00)</points>
+        </wire>
+        <wire output="22" input="77" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="11" wireText="NET11" wireState="0">
+            <points>(573.00,669.00); (573.00,756.00)</points>
+        </wire>
+        <wire output="23" input="78" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="12" wireText="NET12" wireState="0">
+            <points>(588.00,669.00); (588.00,756.00)</points>
+        </wire>
+        <wire output="26" input="79" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="13" wireText="NET13" wireState="0">
+            <points>(634.00,669.00); (634.00,756.00)</points>
+        </wire>
+        <wire output="27" input="80" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="14" wireText="NET14" wireState="0">
+            <points>(649.00,669.00); (649.00,756.00)</points>
+        </wire>
+        <wire output="28" input="81" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="15" wireText="NET15" wireState="0">
+            <points>(664.00,669.00); (664.00,756.00)</points>
+        </wire>
+        <wire output="24" input="82" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="16" wireText="NET16" wireState="0">
+            <points>(603.00,669.00); (603.00,756.00)</points>
+        </wire>
+        <wire output="29" input="83" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="17" wireText="NET17" wireState="0">
+            <points>(680.00,669.00); (680.00,756.00)</points>
+        </wire>
+        <wire output="30" input="84" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="18" wireText="NET18" wireState="0">
+            <points>(695.00,669.00); (695.00,756.00)</points>
+        </wire>
+        <wire output="80" input="39" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="20" wireText="NET20" wireState="0">
+            <points>(129.00,289.00); (116.00,289.00); (116.00,240.00); (308.00,240.00); (308.00,251.00); (320.00,251.00)</points>
+        </wire>
+        <wire output="34" input="67" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="21" wireText="NET21" wireState="0">
+            <points>(320.00,333.00); (220.00,333.00)</points>
+        </wire>
+        <wire output="38" input="68" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="22" wireText="NET22" wireState="0">
+            <points>(320.00,267.00); (220.00,267.00)</points>
+        </wire>
+        <wire output="37" input="69" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="23" wireText="NET23" wireState="0">
+            <points>(320.00,284.00); (220.00,284.00)</points>
+        </wire>
+        <wire output="36" input="70" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="24" wireText="NET24" wireState="0">
+            <points>(320.00,300.00); (220.00,300.00)</points>
+        </wire>
+        <wire output="35" input="71" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="25" wireText="NET25" wireState="0">
+            <points>(320.00,317.00); (220.00,317.00)</points>
+        </wire>
+        <wire output="33" input="72" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="26" wireText="NET26" wireState="0">
+            <points>(320.00,350.00); (220.00,350.00)</points>
+        </wire>
+        <wire output="32" input="73" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="27" wireText="NET27" wireState="0">
+            <points>(320.00,366.00); (220.00,366.00)</points>
+        </wire>
+        <wire output="41" input="0" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="28" wireText="NET28" wireState="0">
+            <points>(320.00,597.00); (97.00,597.00)</points>
+        </wire>
+        <wire output="42" input="1" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="29" wireText="NET29" wireState="0">
+            <points>(320.00,547.00); (212.00,547.00)</points>
+        </wire>
+        <wire output="43" input="2" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="30" wireText="NET30" wireState="0">
+            <points>(320.00,498.00); (97.00,498.00)</points>
+        </wire>
+        <wire output="44" input="3" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="31" wireText="NET31" wireState="0">
+            <points>(320.00,449.00); (212.00,449.00)</points>
+        </wire>
+        <wire output="45" input="4" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="32" wireText="NET32" wireState="0">
+            <points>(320.00,399.00); (97.00,399.00)</points>
+        </wire>
+        <wire output="46" input="5" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="33" wireText="NET33" wireState="0">
+            <points>(320.00,202.00); (97.00,202.00)</points>
+        </wire>
+        <wire output="47" input="6" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="34" wireText="NET34" wireState="0">
+            <points>(320.00,153.00); (212.00,153.00)</points>
+        </wire>
+        <wire output="48" input="7" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="35" wireText="NET35" wireState="0">
+            <points>(320.00,103.00); (97.00,103.00)</points>
+        </wire>
+        <wire output="49" input="8" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="36" wireText="NET36" wireState="0">
+            <points>(961.00,55.00); (1071.00,55.00)</points>
+        </wire>
+        <wire output="50" input="9" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="37" wireText="NET37" wireState="0">
+            <points>(961.00,107.00); (1177.00,107.00)</points>
+        </wire>
+        <wire output="51" input="10" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="38" wireText="NET38" wireState="0">
+            <points>(961.00,159.00); (1071.00,159.00)</points>
+        </wire>
+        <wire output="52" input="11" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="39" wireText="NET39" wireState="0">
+            <points>(961.00,211.00); (1177.00,211.00)</points>
+        </wire>
+        <wire output="53" input="12" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="40" wireText="NET40" wireState="0">
+            <points>(961.00,263.00); (1071.00,263.00)</points>
+        </wire>
+        <wire output="54" input="13" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="41" wireText="NET41" wireState="0">
+            <points>(961.00,315.00); (1177.00,315.00)</points>
+        </wire>
+        <wire output="55" input="14" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="42" wireText="NET42" wireState="0">
+            <points>(961.00,402.00); (1071.00,402.00)</points>
+        </wire>
+        <wire output="56" input="15" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="43" wireText="NET43" wireState="0">
+            <points>(961.00,454.00); (1177.00,454.00)</points>
+        </wire>
+        <wire output="57" input="16" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="44" wireText="NET44" wireState="0">
+            <points>(961.00,610.00); (1071.00,610.00)</points>
+        </wire>
+        <wire output="58" input="17" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="45" wireText="NET45" wireState="0">
+            <points>(961.00,558.00); (1177.00,558.00)</points>
+        </wire>
+        <wire output="59" input="18" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="46" wireText="NET46" wireState="0">
+            <points>(961.00,506.00); (1071.00,506.00)</points>
+        </wire>
+        <wire output="60" input="19" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="47" wireText="NET47" wireState="0">
+            <points>(320.00,630.00); (108.00,630.00); (108.00,648.00); (54.00,648.00); (54.00,633.00)</points>
+        </wire>
+        <wire output="61" input="20" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="48" wireText="NET48" wireState="0">
+            <points>(320.00,580.00); (220.00,580.00); (220.00,588.00); (169.00,588.00); (169.00,582.00)</points>
+        </wire>
+        <wire output="62" input="21" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="49" wireText="NET49" wireState="0">
+            <points>(320.00,531.00); (108.00,531.00); (108.00,552.00); (54.00,552.00); (54.00,534.00)</points>
+        </wire>
+        <wire output="63" input="22" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="50" wireText="NET50" wireState="0">
+            <points>(320.00,482.00); (220.00,482.00); (220.00,490.00); (169.00,490.00); (169.00,484.00)</points>
+        </wire>
+        <wire output="64" input="23" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="51" wireText="NET51" wireState="0">
+            <points>(320.00,432.00); (108.00,432.00); (108.00,448.00); (54.00,448.00); (54.00,435.00)</points>
+        </wire>
+        <wire output="65" input="24" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="52" wireText="NET52" wireState="0">
+            <points>(320.00,235.00); (108.00,235.00); (108.00,248.00); (54.00,248.00); (54.00,237.00)</points>
+        </wire>
+        <wire output="66" input="25" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="53" wireText="NET53" wireState="0">
+            <points>(320.00,185.00); (220.00,185.00); (220.00,194.00); (169.00,194.00); (169.00,188.00)</points>
+        </wire>
+        <wire output="67" input="26" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="54" wireText="NET54" wireState="0">
+            <points>(320.00,136.00); (108.00,136.00); (108.00,152.00); (54.00,152.00); (54.00,139.00)</points>
+        </wire>
+        <wire output="68" input="27" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="55" wireText="NET55" wireState="0">
+            <points>(961.00,90.00); (1060.00,90.00); (1060.00,96.00); (1113.00,96.00); (1113.00,90.00)</points>
+        </wire>
+        <wire output="69" input="28" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="56" wireText="NET56" wireState="0">
+            <points>(961.00,142.00); (1172.00,142.00); (1172.00,160.00); (1219.00,160.00); (1219.00,142.00)</points>
+        </wire>
+        <wire output="70" input="29" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="57" wireText="NET57" wireState="0">
+            <points>(961.00,194.00); (1060.00,194.00); (1060.00,200.00); (1113.00,200.00); (1113.00,194.00)</points>
+        </wire>
+        <wire output="71" input="30" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="58" wireText="NET58" wireState="0">
+            <points>(961.00,246.00); (1172.00,246.00); (1172.00,264.00); (1219.00,264.00); (1219.00,246.00)</points>
+        </wire>
+        <wire output="72" input="31" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="59" wireText="NET59" wireState="0">
+            <points>(961.00,298.00); (1060.00,298.00); (1060.00,304.00); (1113.00,304.00); (1113.00,298.00)</points>
+        </wire>
+        <wire output="73" input="32" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="60" wireText="NET60" wireState="0">
+            <points>(961.00,350.00); (1172.00,350.00); (1172.00,356.00); (1219.00,356.00); (1219.00,350.00)</points>
+        </wire>
+        <wire output="74" input="33" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="61" wireText="NET61" wireState="0">
+            <points>(961.00,437.00); (1060.00,437.00); (1060.00,443.00); (1113.00,443.00); (1113.00,437.00)</points>
+        </wire>
+        <wire output="75" input="34" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="62" wireText="NET62" wireState="0">
+            <points>(961.00,489.00); (1172.00,489.00); (1172.00,504.00); (1219.00,504.00); (1219.00,490.00)</points>
+        </wire>
+        <wire output="76" input="35" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="63" wireText="NET63" wireState="0">
+            <points>(961.00,645.00); (1060.00,645.00); (1060.00,664.00); (1113.00,664.00); (1113.00,645.00)</points>
+        </wire>
+        <wire output="77" input="36" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="64" wireText="NET64" wireState="0">
+            <points>(961.00,593.00); (1172.00,593.00); (1172.00,608.00); (1219.00,608.00); (1219.00,593.00)</points>
+        </wire>
+        <wire output="78" input="37" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="65" wireText="NET65" wireState="0">
+            <points>(961.00,541.00); (1060.00,541.00); (1060.00,547.00); (1113.00,547.00); (1113.00,541.00)</points>
+        </wire>
+        <wire output="0" input="42" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="66" wireText="NET66" wireState="0">
+            <points>(97.00,609.00); (314.00,609.00); (314.00,613.00); (320.00,613.00)</points>
+        </wire>
+        <wire output="1" input="43" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="67" wireText="NET67" wireState="0">
+            <points>(212.00,558.00); (314.00,558.00); (314.00,564.00); (320.00,564.00)</points>
+        </wire>
+        <wire output="2" input="44" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (314.00,510.00); (314.00,514.00); (320.00,514.00)</points>
+        </wire>
+        <wire output="3" input="45" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="68" wireText="NET68" wireState="0">
+            <points>(212.00,460.00); (314.00,460.00); (314.00,465.00); (320.00,465.00)</points>
+        </wire>
+        <wire output="4" input="46" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="69" wireText="NET69" wireState="0">
+            <points>(97.00,411.00); (314.00,411.00); (314.00,416.00); (320.00,416.00)</points>
+        </wire>
+        <wire output="5" input="47" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="70" wireText="NET70" wireState="0">
+            <points>(97.00,213.00); (314.00,213.00); (314.00,218.00); (320.00,218.00)</points>
+        </wire>
+        <wire output="6" input="48" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="71" wireText="NET71" wireState="0">
+            <points>(212.00,164.00); (314.00,164.00); (314.00,169.00); (320.00,169.00)</points>
+        </wire>
+        <wire output="7" input="49" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="72" wireText="NET72" wireState="0">
+            <points>(97.00,115.00); (314.00,115.00); (314.00,120.00); (320.00,120.00)</points>
+        </wire>
+        <wire output="8" input="50" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="73" wireText="NET73" wireState="0">
+            <points>(1071.00,66.00); (967.00,66.00); (967.00,72.00); (961.00,72.00)</points>
+        </wire>
+        <wire output="9" input="51" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="74" wireText="NET74" wireState="0">
+            <points>(1177.00,118.00); (967.00,118.00); (967.00,124.00); (961.00,124.00)</points>
+        </wire>
+        <wire output="10" input="52" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="75" wireText="NET75" wireState="0">
+            <points>(1071.00,170.00); (967.00,170.00); (967.00,176.00); (961.00,176.00)</points>
+        </wire>
+        <wire output="11" input="53" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="76" wireText="NET76" wireState="0">
+            <points>(1177.00,222.00); (967.00,222.00); (967.00,228.00); (961.00,228.00)</points>
+        </wire>
+        <wire output="12" input="54" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="77" wireText="NET77" wireState="0">
+            <points>(1071.00,275.00); (967.00,275.00); (967.00,280.00); (961.00,280.00)</points>
+        </wire>
+        <wire output="13" input="55" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="78" wireText="NET78" wireState="0">
+            <points>(1177.00,327.00); (967.00,327.00); (967.00,333.00); (961.00,333.00)</points>
+        </wire>
+        <wire output="14" input="56" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="79" wireText="NET79" wireState="0">
+            <points>(1071.00,413.00); (967.00,413.00); (967.00,419.00); (961.00,419.00)</points>
+        </wire>
+        <wire output="15" input="57" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="80" wireText="NET80" wireState="0">
+            <points>(1177.00,466.00); (967.00,466.00); (967.00,471.00); (961.00,471.00)</points>
+        </wire>
+        <wire output="16" input="58" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="81" wireText="NET81" wireState="0">
+            <points>(1071.00,621.00); (967.00,621.00); (967.00,628.00); (961.00,628.00)</points>
+        </wire>
+        <wire output="17" input="59" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="82" wireText="NET82" wireState="0">
+            <points>(1177.00,570.00); (967.00,570.00); (967.00,576.00); (961.00,576.00)</points>
+        </wire>
+        <wire output="18" input="60" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="83" wireText="NET83" wireState="0">
+            <points>(1071.00,518.00); (967.00,518.00); (967.00,524.00); (961.00,524.00)</points>
+        </wire>
+    </chip>
+    <emulatorConfiguration version="4" oldestCompatibleVersion="4">
+        <settings>
+            <autoApply value="0"/>
+            <platformSelector id="-1"/>
+        </settings>
+        <platform id="0" friendlyName="GreenPAK DIP Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="1" friendlyName="GreenPAK Advanced Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="2" friendlyName="GreenPAK Pro Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="4" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="5" friendlyName="GreenPAK Advanced Development Platform w/ Logic Level Adapter #1">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="6" friendlyName="ForgeFPGA Deluxe Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="7" friendlyName="ForgeFPGA Evaluation Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="8" friendlyName="SLG51000 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="9" friendlyName="SLG51001 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="10" friendlyName="SLG51002 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="11" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="12" friendlyName="GreenPAK Lite Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="13" friendlyName="HVPAK Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="14" friendlyName="SLG47105V Training Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="15" friendlyName="Power GreenPAK Development Motherboard">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="16" friendlyName="ForgeFPGA Deluxe Development Platform Rev. 2.0">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="17" friendlyName="HVPAK SLG47125 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+    </emulatorConfiguration>
+    <fpga-data>
+        <!--Fpga project data-->
+        <project-data-version>5</project-data-version>
+        <oldestCompatibleVersion>3</oldestCompatibleVersion>
+        <settings>
+            <generateBitstream>
+                <MAX_CPU>16</MAX_CPU>
+                <additionalArguments></additionalArguments>
+                <clockConcurrentOptimization>true</clockConcurrentOptimization>
+                <highDensityIOPacking>false</highDensityIOPacking>
+                <highDensityPackingLogic>true</highDensityPackingLogic>
+                <maximumRoutingIterations>300</maximumRoutingIterations>
+                <placeAndTrialRoute>false</placeAndTrialRoute>
+                <placeAndTrialRouteIterationCount>20</placeAndTrialRouteIterationCount>
+            </generateBitstream>
+            <simulation>
+                <wavedumpOutputFormat>1</wavedumpOutputFormat>
+            </simulation>
+            <synthesize>
+                <additionalArguments></additionalArguments>
+                <flatten>true</flatten>
+                <keep>false</keep>
+                <noDSP>true</noDSP>
+                <useABC9>true</useABC9>
+            </synthesize>
+        </settings>
+        <openedTabs>
+            <openedTab>main.v</openedTab>
+            <openedTab>I/O Planner</openedTab>
+        </openedTabs>
+        <pipelineStagesStates>
+            <pipelineStageState>
+                <pipelineStage>0</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+            <pipelineStageState>
+                <pipelineStage>1</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+        </pipelineStagesStates>
+        <modules>
+            <scr>
+                <module filename="main.v"/>
+            </scr>
+            <lib/>
+            <sim/>
+            <netlists/>
+            <timing-constraints/>
+        </modules>
+        <io-spec-tool>
+            <records filter="16">
+                <record id="IOB_t[0:0]_xy[31:4]_in0">
+                    <port-name>b</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:5]_in0">
+                    <port-name>a</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:6]_out0">
+                    <port-name>LED</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:6]_out1">
+                    <port-name>LED_en</port-name>
+                </record>
+            </records>
+        </io-spec-tool>
+        <macrocell-mode-data>
+            <scene-data>
+                <scene-width>32767</scene-width>
+                <scene-height>32767</scene-height>
+                <scene-snapToGrid>1</scene-snapToGrid>
+            </scene-data>
+            <macrocells-data>
+                <macrocell>
+                    <macrocell-id>18</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input18</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>-240</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>19</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>20</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input20</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>21</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>22</macrocell-id>
+                    <macrocell-type>4</macrocell-type>
+                    <macrocell-title>NOT Gate</macrocell-title>
+                    <macrocell-name>not22</macrocell-name>
+                    <macrocell-posx>-100</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>23</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>24</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>25</macrocell-id>
+                    <macrocell-type>8</macrocell-type>
+                    <macrocell-title>NAND Gate</macrocell-title>
+                    <macrocell-name>nand25</macrocell-name>
+                    <macrocell-posx>240</macrocell-posx>
+                    <macrocell-posy>-200</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>26</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                        <port>
+                            <port-id>27</port-id>
+                            <port-index>1</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>28</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>29</macrocell-id>
+                    <macrocell-type>3</macrocell-type>
+                    <macrocell-title>OUT</macrocell-title>
+                    <macrocell-name>output29</macrocell-name>
+                    <macrocell-posx>640</macrocell-posx>
+                    <macrocell-posy>-140</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>30</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports/>
+                </macrocell>
+            </macrocells-data>
+            <wires-data>
+                <wire>
+                    <wire-id>31</wire-id>
+                    <wire-start-port-id>19</wire-start-port-id>
+                    <wire-end-port-id>26</wire-end-port-id>
+                    <wire-name>wire31</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>32</wire-id>
+                    <wire-start-port-id>21</wire-start-port-id>
+                    <wire-end-port-id>23</wire-end-port-id>
+                    <wire-name>wire32</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>33</wire-id>
+                    <wire-start-port-id>24</wire-start-port-id>
+                    <wire-end-port-id>27</wire-end-port-id>
+                    <wire-name>wire33</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>34</wire-id>
+                    <wire-start-port-id>28</wire-start-port-id>
+                    <wire-end-port-id>30</wire-end-port-id>
+                    <wire-name>wire34</wire-name>
+                </wire>
+            </wires-data>
+        </macrocell-mode-data>
+        <!--Fpga project data END-->
+    </fpga-data>
+    <projectData>
+        <specs>
+            <lastModify lastModifyValue="11.11.2025 11:53:44"/>
+            <vddSpecs vddMin="1.05" vddTyp="1.1" vddMax="1.15"/>
+            <vdd2Specs vdd2Min="1.71" vdd2Typ="2.5" vdd2Max="3.3"/>
+            <tempSpecs tempMin="-40" tempTyp="25" tempMax="85"/>
+        </specs>
+        <projectDataFields>
+            <textLineDataField name="Customer Name" id="2" text=""/>
+            <textLineDataField name="Customer Project Name" id="3" text=""/>
+            <textLineDataField name="Customer Project Number" id="4" text=""/>
+            <textLineDataField name="Customer Version Number" id="5" text=""/>
+            <multiTextLineDataField>
+                <textLineDataField name="Notes" id="6" text=""/>
+            </multiTextLineDataField>
+        </projectDataFields>
+    </projectData>
+    <i2cTool>
+        <i2cDebugger version="1"/>
+        <i2cStepper version="1" rowCount="0"/>
+        <i2cRegsTable version="1" tabCount="0"/>
+    </i2cTool>
+<logicAnalyzer>
+    <metadata>
+        <autosavePreset>-1</autosavePreset>
+        <currentPreset>-1</currentPreset>
+        <version>3</version>
+    </metadata>
+    <presetList/>
+</logicAnalyzer>
+
+</GPDProject>


### PR DESCRIPTION
## PR Summary:
This PR adds basic Verilog examples for fundamental logic gates (AND, OR, NOT, NOR, NAND, XOR).

### Changes:

- Added `README.md` and six folders with Verilog implementations for each gate.

## To Test:

- Synthesize each module separately and test via MicroPython GPIO toggling (details in README).
