### PR TITLE
refactor(docs): fix typos and broken links in documentation

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -102,7 +102,7 @@ We have already generated and hosted a bitstream to blink led [here](https://git
 
 Checkout guide to learn how to generate your own fpga design [here](./generating_your_first_bitstream.md).
 
-Onces you have done this go to arduino and hit compile your compilation should finish without error if error occurs don't we have s discord hope on there. 
+Once you have done this, open Arduino IDE and click on Compile. The compilation should complete without any errors. If you encounter any errors, don’t worry—we have a Discord community. Hop in there and we’ll help you out.
 
 If the compilation has been done without any error then it's time to connect the board in boot mode " PRESS THE BOOT BUTTON WHILE CONNECTING THE BOARD WITH PC" ( this should be done only the first time of setting up if arduino are if you have programmed the board with any other way last time).
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -25,7 +25,8 @@ The beauty of this setup is that you can reprogram the FPGA an unlimited number 
 As discussed earlier, we’ll need to learn how compilation works for both systems: the FPGA and the micro-controller (RP2350/RP2040).
 
 The binary files that the FPGA understands are called **bitstreams**.  
-Follow the guide here to learn how to generate a bitstream for the FPGA:  [Generating Your First Bitstream](https://vicharak-in.github.io/shrike-lite/generating_your_first_bitstream.html)
+Follow the guide here to learn how to generate a bitstream for the FPGA: 
+ [Generating Your First Bitstream](https://vicharak-in.github.io/shrike/generating_your_first_bitstream.html)
 
 Once you have the bitstream, you’re ready to load it into the FPGA through a microcontroller (RP2040) program.
 

--- a/docs/reading_list.md
+++ b/docs/reading_list.md
@@ -24,8 +24,3 @@ This is a compilation of the resources and references suggested for Shrike and F
 3. [icebreaker-Project](https://github.com/icebreaker-fpga/icebreaker)
 4. [pico-ice](https://pico-ice.tinyvision.ai/)
    
-
-## 3. Communities to Join
-1. [ULX3S](https://discord.gg/WwWtuk5w)
-2. [TinyVision](https://discord.gg/RQXEF59m)
-3. [1bitsquared](https://discord.gg/nrnGxCuF)


### PR DESCRIPTION
- Fixed the minor typo in the Getting Started guide
- Fixed the broken link to the bitstream setup in introduction.md
- Removed the expired links from the reading_list.md