### PR TITLE
Add an example of an 8-bit cpu on Shrike Lite

### DIFF
--- a/examples/Vector-8/README.md
+++ b/examples/Vector-8/README.md
@@ -1,0 +1,103 @@
+# Vector - 8
+
+This project implements a custom **8-bit Soft-Core CPU** on the Vicharak's **Shrike Lite** board. It serves as a hands-on introduction to Computer Architecture.
+
+Expanding upon the Vector-4 architecture, this CPU doubles the data width and significantly expands the instruction set while maintaining a compact footprint under **140 CLBs**. It is controlled entirely via **SPI**, where the RP2040 acts as the master, sending 16-bit instruction packets and single-stepping the execution.
+
+---
+
+## System Architecture
+
+The system follows a hybrid controller-target design:
+* **RP2040 (Master):** Manages high-level logic, instruction sequencing, and user interface.
+* **FPGA (Slave):** Contains the 8-bit CPU core (Accumulator-based), ALU, and status registers.
+
+### Specifications
+| Feature | Detail |
+| :--- | :--- |
+| **Data Width** | 8-bit (Full Byte) |
+| **Instruction Set** | 32-ISA (5-bit Opcodes) |
+| **Clocking** | Manual Stepping via SPI (Synchronous to FPGA System Clock) |
+| **Interface** | 16-bit SPI Protocol (Double-Byte Packet) |
+
+---
+
+<img width="2816" height="1504" alt="8-bit_cpu" src="https://github.com/user-attachments/assets/f5d97bca-0007-4263-ad65-2c8b7dee1aeb" />
+
+## The SPI Interface
+
+To interact with the 8-bit core, the RP2040 sends **16-bit packets** (two 8-bit transfers). The FPGA assembles these into a single instruction and executes it on the rising edge of the internal step signal.
+
+### Input Packet (RP2040 -> FPGA)
+The instruction is sent across two bytes. 
+
+**Byte 1: Command**
+| Bit [7:5] | Bit [4:0] |
+| :---: | :---: |
+| **Unused** | **OPCODE** |
+| - | 5-bit Instruction Identifier |
+
+**Byte 2: Data**
+| Bit [7:0] |
+| :---: |
+| **OPERAND / DATA** |
+| 8-bit Immediate Value or Address |
+
+### Output Packet (FPGA -> RP2040)
+The FPGA replies with the current state of the Accumulator for verification. Because the SPI transfer occurs simultaneously with execution, the MISO line returns the result of the *previous* instruction.
+| Bit [7:0] |
+| :---: |
+| **ACC (Accumulator Value)** |
+| Current 8-bit result of the previous operation |
+
+---
+
+## Instruction Set Architecture (ISA)
+
+The CPU supports an expanded set of 32 operations. Below are the primary validated opcodes.
+
+| Opcode | Name | Description |
+| :--- | :--- | :--- |
+| `0x00` | **NOP** | No Operation |
+| `0x01` | **LDA** | Load Accumulator with 8-bit Data |
+| `0x02` | **ADD** | `Acc = Acc + Data` |
+| `0x03` | **SUB** | `Acc = Acc - Data` |
+| `0x04` | **AND** | Bitwise AND |
+| `0x05` | **OR** | Bitwise OR |
+| `0x06` | **XOR** | Bitwise XOR |
+| `0x07` | **LSL** | Logical Shift Left |
+| `0x08` | **LSR** | Logical Shift Right |
+| `0x09` | **ROL** | Rotate Left |
+| `0x0A` | **ROR** | Rotate Right |
+| `0x0B` | **INC** | `Acc = Acc + 1` |
+| `0x0C` | **DEC** | `Acc = Acc - 1` |
+| `0x0D` | **JMP** | Jump to Address (Update PC) |
+| `0x0E` | **JZ** | Jump to Address if Zero Flag is High |
+| `0x0F` | **JNZ** | Jump to Address if Zero Flag is Low |
+
+---
+
+## Hardware Connections
+
+### Top Module Interface
+These signals correspond to the top-level Verilog module (`top.v`).
+
+| Signal        | Direction | Description                                  |
+|---------------|-----------|----------------------------------------------|
+| `clk`         | In        | System clock (50 MHz typical)                |
+| `clk_en`      | Out       | Clock enable (always 1)                      |
+| `rst_n`       | In        | Reset Pin (active low)                       |
+| `spi_ss_n`    | In        | Input target select signal (active low)      |
+| `spi_sck`     | In        | Input SPI clock signal                       |
+| `spi_mosi`    | In        | Input from controller (Master Out)           |
+| `spi_miso`    | Out       | Output to controller (Master In)             |
+
+### Pin Mapping Table
+
+| Signal Function | FPGA Pin (GPIO) | RP2040 Pin | Direction |
+| :--- | :---: | :---: | :--- |
+| **SPI Clock** | 3 | 2 | RP2040 Output -> FPGA Input |
+| **Chip Select** | 4 | 1 | RP2040 Output -> FPGA Input |
+| **MOSI** | 5 | 3 | RP2040 Output -> FPGA Input |
+| **MISO** | 6 | 0 | FPGA Output -> RP2040 Input |
+| **Reset** | 18 | 14 | RP2040 Output -> FPGA Input |

--- a/examples/Vector-8/Vector_8.ffpga
+++ b/examples/Vector-8/Vector_8.ffpga
@@ -1,0 +1,935 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GPDProject version="40" oldestCompatibleVersion="32" GPDVersion="6.51.001" lastChange="14 Jan 2026 00:39:10" projectChecksumState="1" projectChecksum="ca18656c">
+    <generalProjectSettings/>
+    <chip family="04" type="06" friendlyName="FFPGA" partNumber="67" package="26">
+        <nvmData registerLenght="480">0 0 0 28 0 0 0 0 A5 A5 A5 A5 0 0 0 0 0 0 0 0 5A 5A 5A 5A 0 0 0 0 22 22 22 22 22 22 22 22 22 22 0 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</nvmData>
+        <checksum crc32="0x451C1D42" version="2"/>
+        <VDDItem id="0">
+            <item id="0" caption="VDD (PIN 22)">
+                <graphics pos="(1350.00,143.10)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <VDDItem id="1">
+            <item id="1" caption="VDDIO (PIN 21)">
+                <graphics pos="(1350.00,226.67)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <item id="2" caption="GND (PIN 12)">
+            <graphics pos="(1350.00,298.48)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="3" caption="FPGA">
+            <graphics pos="(0.00,0.00)" angle="0" flipping="0" hidden="0" tOrigin="(640.00,442.50)"/>
+        </item>
+        <item id="4" caption="GPIO0 (PIN 13)">
+            <graphics pos="(35.00,592.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="5" caption="GPIO1 (PIN 14)">
+            <graphics pos="(150.00,542.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="6" caption="GPIO2 (PIN 15)">
+            <graphics pos="(35.00,493.59)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="7" caption="GPIO3 (PIN 16)">
+            <graphics pos="(150.00,444.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="8" caption="GPIO4 (PIN 17)">
+            <graphics pos="(35.00,394.74)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="9" caption="GPIO5 (PIN 18)">
+            <graphics pos="(35.00,197.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="10" caption="GPIO6 (PIN 19)">
+            <graphics pos="(150.00,148.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="11" caption="GPIO7 (PIN 20)">
+            <graphics pos="(35.00,98.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="12" caption="GPIO8 (PIN 23)">
+            <graphics pos="(1094.00,49.99)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="13" caption="GPIO9 (PIN 24)">
+            <graphics pos="(1200.00,102.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="14" caption="GPIO10 (PIN 1)">
+            <graphics pos="(1094.00,154.03)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="15" caption="GPIO11 (PIN 2)">
+            <graphics pos="(1200.00,206.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="16" caption="GPIO12 (PIN 3)">
+            <graphics pos="(1094.00,258.20)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="17" caption="GPIO13 (PIN 4)">
+            <graphics pos="(1200.00,310.28)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="18" caption="GPIO14 (PIN 5)">
+            <graphics pos="(1094.00,397.09)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="19" caption="GPIO15 (PIN 6)">
+            <graphics pos="(1200.00,449.75)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="20" caption="GPIO18 (PIN 9/GrP0)">
+            <graphics pos="(1094.00,604.84)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="21" caption="GPIO17 (PIN 8/GrP1)">
+            <graphics pos="(1200.00,553.34)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="22" caption="GPIO16 (PIN 7/GrP2)">
+            <graphics pos="(1094.00,501.25)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="23" caption="nRST (PIN 11)">
+            <graphics pos="(1094.00,356.17)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="24" caption="nSLEEP (PIN 10)">
+            <graphics pos="(1200.00,374.22)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="25" caption="OSC">
+            <graphics pos="(150.00,64.53)" angle="0" flipping="0" hidden="0" tOrigin="(25.00,10.00)"/>
+        </item>
+        <item id="26" caption="Phase-Locked Loop">
+            <graphics pos="(149.73,246.87)" angle="180" flipping="0" hidden="0" tOrigin="(25.00,70.00)"/>
+        </item>
+        <item id="27" caption="BRAM">
+            <graphics pos="(616.77,701.83)" angle="90" flipping="0" hidden="0" tOrigin="(25.00,100.00)"/>
+        </item>
+        <item id="28" caption="FPGA Core">
+            <graphics pos="(340.90,49.43)" angle="0" flipping="0" hidden="0" tOrigin="(300.00,300.00)"/>
+        </item>
+        <wire output="79" input="65" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (236.00,80.00); (236.00,250.00); (220.00,250.00)</points>
+        </wire>
+        <wire output="2" input="66" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (226.00,510.00); (226.00,383.00); (220.00,383.00)</points>
+        </wire>
+        <wire output="83" input="85" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="0" wireText="NET0" wireState="0">
+            <points>(129.00,344.00); (116.00,344.00); (116.00,392.00); (308.00,392.00); (308.00,383.00); (320.00,383.00)</points>
+        </wire>
+        <wire output="84" input="86" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="1" wireText="NET1" wireState="0">
+            <points>(711.00,669.00); (711.00,756.00)</points>
+        </wire>
+        <wire output="85" input="87" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="2" wireText="NET2" wireState="0">
+            <points>(726.00,669.00); (726.00,756.00)</points>
+        </wire>
+        <wire output="86" input="88" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="3" wireText="NET3" wireState="0">
+            <points>(220.00,70.00); (320.00,70.00)</points>
+        </wire>
+        <wire output="79" input="38" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (314.00,80.00); (314.00,87.00); (320.00,87.00)</points>
+        </wire>
+        <wire output="39" input="63" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="5" wireText="NET5" wireState="0">
+            <points>(320.00,54.00); (116.00,54.00); (116.00,75.00); (129.00,75.00)</points>
+        </wire>
+        <wire output="20" input="62" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="6" wireText="NET6" wireState="0">
+            <points>(1177.00,384.00); (967.00,384.00); (967.00,385.00); (961.00,385.00)</points>
+        </wire>
+        <wire output="19" input="61" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="7" wireText="NET7" wireState="0">
+            <points>(1071.00,366.00); (967.00,366.00); (967.00,367.00); (961.00,367.00)</points>
+        </wire>
+        <wire output="82" input="41" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="8" wireText="NET8" wireState="0">
+            <points>(642.00,847.00); (642.00,853.00); (308.00,853.00); (308.00,645.00); (320.00,645.00)</points>
+        </wire>
+        <wire output="21" input="75" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="9" wireText="NET9" wireState="0">
+            <points>(557.00,669.00); (557.00,756.00)</points>
+        </wire>
+        <wire output="25" input="76" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="10" wireText="NET10" wireState="0">
+            <points>(618.00,669.00); (618.00,756.00)</points>
+        </wire>
+        <wire output="22" input="77" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="11" wireText="NET11" wireState="0">
+            <points>(573.00,669.00); (573.00,756.00)</points>
+        </wire>
+        <wire output="23" input="78" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="12" wireText="NET12" wireState="0">
+            <points>(588.00,669.00); (588.00,756.00)</points>
+        </wire>
+        <wire output="26" input="79" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="13" wireText="NET13" wireState="0">
+            <points>(634.00,669.00); (634.00,756.00)</points>
+        </wire>
+        <wire output="27" input="80" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="14" wireText="NET14" wireState="0">
+            <points>(649.00,669.00); (649.00,756.00)</points>
+        </wire>
+        <wire output="28" input="81" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="15" wireText="NET15" wireState="0">
+            <points>(664.00,669.00); (664.00,756.00)</points>
+        </wire>
+        <wire output="24" input="82" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="16" wireText="NET16" wireState="0">
+            <points>(603.00,669.00); (603.00,756.00)</points>
+        </wire>
+        <wire output="29" input="83" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="17" wireText="NET17" wireState="0">
+            <points>(680.00,669.00); (680.00,756.00)</points>
+        </wire>
+        <wire output="30" input="84" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="18" wireText="NET18" wireState="0">
+            <points>(695.00,669.00); (695.00,756.00)</points>
+        </wire>
+        <wire output="80" input="39" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="20" wireText="NET20" wireState="0">
+            <points>(129.00,289.00); (116.00,289.00); (116.00,240.00); (308.00,240.00); (308.00,251.00); (320.00,251.00)</points>
+        </wire>
+        <wire output="34" input="67" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="21" wireText="NET21" wireState="0">
+            <points>(320.00,333.00); (220.00,333.00)</points>
+        </wire>
+        <wire output="38" input="68" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="22" wireText="NET22" wireState="0">
+            <points>(320.00,267.00); (220.00,267.00)</points>
+        </wire>
+        <wire output="37" input="69" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="23" wireText="NET23" wireState="0">
+            <points>(320.00,284.00); (220.00,284.00)</points>
+        </wire>
+        <wire output="36" input="70" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="24" wireText="NET24" wireState="0">
+            <points>(320.00,300.00); (220.00,300.00)</points>
+        </wire>
+        <wire output="35" input="71" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="25" wireText="NET25" wireState="0">
+            <points>(320.00,317.00); (220.00,317.00)</points>
+        </wire>
+        <wire output="33" input="72" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="26" wireText="NET26" wireState="0">
+            <points>(320.00,350.00); (220.00,350.00)</points>
+        </wire>
+        <wire output="32" input="73" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="27" wireText="NET27" wireState="0">
+            <points>(320.00,366.00); (220.00,366.00)</points>
+        </wire>
+        <wire output="41" input="0" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="28" wireText="NET28" wireState="0">
+            <points>(320.00,597.00); (97.00,597.00)</points>
+        </wire>
+        <wire output="42" input="1" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="29" wireText="NET29" wireState="0">
+            <points>(320.00,547.00); (212.00,547.00)</points>
+        </wire>
+        <wire output="43" input="2" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="30" wireText="NET30" wireState="0">
+            <points>(320.00,498.00); (97.00,498.00)</points>
+        </wire>
+        <wire output="44" input="3" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="31" wireText="NET31" wireState="0">
+            <points>(320.00,449.00); (212.00,449.00)</points>
+        </wire>
+        <wire output="45" input="4" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="32" wireText="NET32" wireState="0">
+            <points>(320.00,399.00); (97.00,399.00)</points>
+        </wire>
+        <wire output="46" input="5" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="33" wireText="NET33" wireState="0">
+            <points>(320.00,202.00); (97.00,202.00)</points>
+        </wire>
+        <wire output="47" input="6" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="34" wireText="NET34" wireState="0">
+            <points>(320.00,153.00); (212.00,153.00)</points>
+        </wire>
+        <wire output="48" input="7" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="35" wireText="NET35" wireState="0">
+            <points>(320.00,103.00); (97.00,103.00)</points>
+        </wire>
+        <wire output="49" input="8" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="36" wireText="NET36" wireState="0">
+            <points>(961.00,55.00); (1071.00,55.00)</points>
+        </wire>
+        <wire output="50" input="9" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="37" wireText="NET37" wireState="0">
+            <points>(961.00,107.00); (1177.00,107.00)</points>
+        </wire>
+        <wire output="51" input="10" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="38" wireText="NET38" wireState="0">
+            <points>(961.00,159.00); (1071.00,159.00)</points>
+        </wire>
+        <wire output="52" input="11" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="39" wireText="NET39" wireState="0">
+            <points>(961.00,211.00); (1177.00,211.00)</points>
+        </wire>
+        <wire output="53" input="12" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="40" wireText="NET40" wireState="0">
+            <points>(961.00,263.00); (1071.00,263.00)</points>
+        </wire>
+        <wire output="54" input="13" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="41" wireText="NET41" wireState="0">
+            <points>(961.00,315.00); (1177.00,315.00)</points>
+        </wire>
+        <wire output="55" input="14" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="42" wireText="NET42" wireState="0">
+            <points>(961.00,402.00); (1071.00,402.00)</points>
+        </wire>
+        <wire output="56" input="15" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="43" wireText="NET43" wireState="0">
+            <points>(961.00,454.00); (1177.00,454.00)</points>
+        </wire>
+        <wire output="57" input="16" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="44" wireText="NET44" wireState="0">
+            <points>(961.00,610.00); (1071.00,610.00)</points>
+        </wire>
+        <wire output="58" input="17" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="45" wireText="NET45" wireState="0">
+            <points>(961.00,558.00); (1177.00,558.00)</points>
+        </wire>
+        <wire output="59" input="18" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="46" wireText="NET46" wireState="0">
+            <points>(961.00,506.00); (1071.00,506.00)</points>
+        </wire>
+        <wire output="60" input="19" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="47" wireText="NET47" wireState="0">
+            <points>(320.00,630.00); (108.00,630.00); (108.00,648.00); (54.00,648.00); (54.00,633.00)</points>
+        </wire>
+        <wire output="61" input="20" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="48" wireText="NET48" wireState="0">
+            <points>(320.00,580.00); (220.00,580.00); (220.00,588.00); (169.00,588.00); (169.00,582.00)</points>
+        </wire>
+        <wire output="62" input="21" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="49" wireText="NET49" wireState="0">
+            <points>(320.00,531.00); (108.00,531.00); (108.00,552.00); (54.00,552.00); (54.00,534.00)</points>
+        </wire>
+        <wire output="63" input="22" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="50" wireText="NET50" wireState="0">
+            <points>(320.00,482.00); (220.00,482.00); (220.00,490.00); (169.00,490.00); (169.00,484.00)</points>
+        </wire>
+        <wire output="64" input="23" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="51" wireText="NET51" wireState="0">
+            <points>(320.00,432.00); (108.00,432.00); (108.00,448.00); (54.00,448.00); (54.00,435.00)</points>
+        </wire>
+        <wire output="65" input="24" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="52" wireText="NET52" wireState="0">
+            <points>(320.00,235.00); (108.00,235.00); (108.00,248.00); (54.00,248.00); (54.00,237.00)</points>
+        </wire>
+        <wire output="66" input="25" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="53" wireText="NET53" wireState="0">
+            <points>(320.00,185.00); (220.00,185.00); (220.00,194.00); (169.00,194.00); (169.00,188.00)</points>
+        </wire>
+        <wire output="67" input="26" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="54" wireText="NET54" wireState="0">
+            <points>(320.00,136.00); (108.00,136.00); (108.00,152.00); (54.00,152.00); (54.00,139.00)</points>
+        </wire>
+        <wire output="68" input="27" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="55" wireText="NET55" wireState="0">
+            <points>(961.00,90.00); (1060.00,90.00); (1060.00,96.00); (1113.00,96.00); (1113.00,90.00)</points>
+        </wire>
+        <wire output="69" input="28" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="56" wireText="NET56" wireState="0">
+            <points>(961.00,142.00); (1172.00,142.00); (1172.00,160.00); (1219.00,160.00); (1219.00,142.00)</points>
+        </wire>
+        <wire output="70" input="29" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="57" wireText="NET57" wireState="0">
+            <points>(961.00,194.00); (1060.00,194.00); (1060.00,200.00); (1113.00,200.00); (1113.00,194.00)</points>
+        </wire>
+        <wire output="71" input="30" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="58" wireText="NET58" wireState="0">
+            <points>(961.00,246.00); (1172.00,246.00); (1172.00,264.00); (1219.00,264.00); (1219.00,246.00)</points>
+        </wire>
+        <wire output="72" input="31" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="59" wireText="NET59" wireState="0">
+            <points>(961.00,298.00); (1060.00,298.00); (1060.00,304.00); (1113.00,304.00); (1113.00,298.00)</points>
+        </wire>
+        <wire output="73" input="32" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="60" wireText="NET60" wireState="0">
+            <points>(961.00,350.00); (1172.00,350.00); (1172.00,356.00); (1219.00,356.00); (1219.00,350.00)</points>
+        </wire>
+        <wire output="74" input="33" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="61" wireText="NET61" wireState="0">
+            <points>(961.00,437.00); (1060.00,437.00); (1060.00,443.00); (1113.00,443.00); (1113.00,437.00)</points>
+        </wire>
+        <wire output="75" input="34" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="62" wireText="NET62" wireState="0">
+            <points>(961.00,489.00); (1172.00,489.00); (1172.00,504.00); (1219.00,504.00); (1219.00,490.00)</points>
+        </wire>
+        <wire output="76" input="35" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="63" wireText="NET63" wireState="0">
+            <points>(961.00,645.00); (1060.00,645.00); (1060.00,664.00); (1113.00,664.00); (1113.00,645.00)</points>
+        </wire>
+        <wire output="77" input="36" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="64" wireText="NET64" wireState="0">
+            <points>(961.00,593.00); (1172.00,593.00); (1172.00,608.00); (1219.00,608.00); (1219.00,593.00)</points>
+        </wire>
+        <wire output="78" input="37" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="65" wireText="NET65" wireState="0">
+            <points>(961.00,541.00); (1060.00,541.00); (1060.00,547.00); (1113.00,547.00); (1113.00,541.00)</points>
+        </wire>
+        <wire output="0" input="42" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="66" wireText="NET66" wireState="0">
+            <points>(97.00,609.00); (314.00,609.00); (314.00,613.00); (320.00,613.00)</points>
+        </wire>
+        <wire output="1" input="43" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="67" wireText="NET67" wireState="0">
+            <points>(212.00,558.00); (314.00,558.00); (314.00,564.00); (320.00,564.00)</points>
+        </wire>
+        <wire output="2" input="44" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (314.00,510.00); (314.00,514.00); (320.00,514.00)</points>
+        </wire>
+        <wire output="3" input="45" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="68" wireText="NET68" wireState="0">
+            <points>(212.00,460.00); (314.00,460.00); (314.00,465.00); (320.00,465.00)</points>
+        </wire>
+        <wire output="4" input="46" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="69" wireText="NET69" wireState="0">
+            <points>(97.00,411.00); (314.00,411.00); (314.00,416.00); (320.00,416.00)</points>
+        </wire>
+        <wire output="5" input="47" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="70" wireText="NET70" wireState="0">
+            <points>(97.00,213.00); (314.00,213.00); (314.00,218.00); (320.00,218.00)</points>
+        </wire>
+        <wire output="6" input="48" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="71" wireText="NET71" wireState="0">
+            <points>(212.00,164.00); (314.00,164.00); (314.00,169.00); (320.00,169.00)</points>
+        </wire>
+        <wire output="7" input="49" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="72" wireText="NET72" wireState="0">
+            <points>(97.00,115.00); (314.00,115.00); (314.00,120.00); (320.00,120.00)</points>
+        </wire>
+        <wire output="8" input="50" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="73" wireText="NET73" wireState="0">
+            <points>(1071.00,66.00); (967.00,66.00); (967.00,72.00); (961.00,72.00)</points>
+        </wire>
+        <wire output="9" input="51" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="74" wireText="NET74" wireState="0">
+            <points>(1177.00,118.00); (967.00,118.00); (967.00,124.00); (961.00,124.00)</points>
+        </wire>
+        <wire output="10" input="52" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="75" wireText="NET75" wireState="0">
+            <points>(1071.00,170.00); (967.00,170.00); (967.00,176.00); (961.00,176.00)</points>
+        </wire>
+        <wire output="11" input="53" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="76" wireText="NET76" wireState="0">
+            <points>(1177.00,222.00); (967.00,222.00); (967.00,228.00); (961.00,228.00)</points>
+        </wire>
+        <wire output="12" input="54" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="77" wireText="NET77" wireState="0">
+            <points>(1071.00,275.00); (967.00,275.00); (967.00,280.00); (961.00,280.00)</points>
+        </wire>
+        <wire output="13" input="55" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="78" wireText="NET78" wireState="0">
+            <points>(1177.00,327.00); (967.00,327.00); (967.00,333.00); (961.00,333.00)</points>
+        </wire>
+        <wire output="14" input="56" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="79" wireText="NET79" wireState="0">
+            <points>(1071.00,413.00); (967.00,413.00); (967.00,419.00); (961.00,419.00)</points>
+        </wire>
+        <wire output="15" input="57" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="80" wireText="NET80" wireState="0">
+            <points>(1177.00,466.00); (967.00,466.00); (967.00,471.00); (961.00,471.00)</points>
+        </wire>
+        <wire output="16" input="58" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="81" wireText="NET81" wireState="0">
+            <points>(1071.00,621.00); (967.00,621.00); (967.00,628.00); (961.00,628.00)</points>
+        </wire>
+        <wire output="17" input="59" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="82" wireText="NET82" wireState="0">
+            <points>(1177.00,570.00); (967.00,570.00); (967.00,576.00); (961.00,576.00)</points>
+        </wire>
+        <wire output="18" input="60" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="83" wireText="NET83" wireState="0">
+            <points>(1071.00,518.00); (967.00,518.00); (967.00,524.00); (961.00,524.00)</points>
+        </wire>
+    </chip>
+    <emulatorConfiguration version="4" oldestCompatibleVersion="4">
+        <settings>
+            <autoApply value="0"/>
+            <platformSelector id="-1"/>
+        </settings>
+        <platform id="0" friendlyName="GreenPAK DIP Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="1" friendlyName="GreenPAK Advanced Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="2" friendlyName="GreenPAK Pro Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="4" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="5" friendlyName="GreenPAK Advanced Development Platform w/ Logic Level Adapter #1">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="6" friendlyName="ForgeFPGA Deluxe Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="7" friendlyName="ForgeFPGA Evaluation Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="8" friendlyName="SLG51000 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="9" friendlyName="SLG51001 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="10" friendlyName="SLG51002 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="11" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="12" friendlyName="GreenPAK Lite Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="13" friendlyName="HVPAK Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="14" friendlyName="SLG47105V Training Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="15" friendlyName="Power GreenPAK Development Motherboard">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="16" friendlyName="ForgeFPGA Deluxe Development Platform Rev. 2.0">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="17" friendlyName="HVPAK SLG47125 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="18" friendlyName="Go Configure Development Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="19" friendlyName="HVPAK SLG47125 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="20" friendlyName="Go Configure Development Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+    </emulatorConfiguration>
+    <fpga-data>
+        <!--Fpga project data-->
+        <project-data-version>7</project-data-version>
+        <oldestCompatibleVersion>6</oldestCompatibleVersion>
+        <settings>
+            <generateBitstream>
+                <MAX_CPU>16</MAX_CPU>
+                <additionalArguments></additionalArguments>
+                <clockConcurrentOptimization>true</clockConcurrentOptimization>
+                <compilerVersion>23</compilerVersion>
+                <highDensityIOPacking>false</highDensityIOPacking>
+                <highDensityPackingLogic>true</highDensityPackingLogic>
+                <maximumRoutingIterations>300</maximumRoutingIterations>
+                <placeAndTrialRoute>false</placeAndTrialRoute>
+                <placeAndTrialRouteIterationCount>20</placeAndTrialRouteIterationCount>
+                <timingAnalysisCorner>0</timingAnalysisCorner>
+            </generateBitstream>
+            <simulation>
+                <wavedumpOutputFormat>1</wavedumpOutputFormat>
+            </simulation>
+            <synthesize>
+                <additionalArguments></additionalArguments>
+                <enableHardMultiplexerResources>true</enableHardMultiplexerResources>
+                <flatten>true</flatten>
+                <keep>false</keep>
+                <multiplexerResourcesNumber>5</multiplexerResourcesNumber>
+                <noDSP>true</noDSP>
+                <useABC9>true</useABC9>
+            </synthesize>
+        </settings>
+        <openedTabs>
+            <openedTab>main.v</openedTab>
+            <openedTab>alu_8bit.v</openedTab>
+            <openedTab>cpu_core.v</openedTab>
+            <openedTab>spi_target.v</openedTab>
+            <openedTab>I/O Planner</openedTab>
+        </openedTabs>
+        <pipelineStagesStates>
+            <pipelineStageState>
+                <pipelineStage>0</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+            <pipelineStageState>
+                <pipelineStage>1</pipelineStage>
+                <pipelineState>0</pipelineState>
+            </pipelineStageState>
+        </pipelineStagesStates>
+        <modules>
+            <scr>
+                <module filename="main.v"/>
+                <module filename="alu_8bit.v"/>
+                <module filename="cpu_core.v"/>
+                <module filename="spi_target.v"/>
+            </scr>
+            <lib/>
+            <sim/>
+            <netlists/>
+            <timing-constraints/>
+            <full-chip-simulation-models/>
+            <placement-constraints/>
+        </modules>
+        <io-spec-tool>
+            <records filter="16">
+                <record id="CLK_t[0:0]_W_in0">
+                    <port-name>clk</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:10]_in0">
+                    <port-name>spi_ss_n</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:22]_in0">
+                    <port-name>spi_mosi</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:23]_out0">
+                    <port-name>spi_miso</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:23]_out1">
+                    <port-name>spi_miso_en</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:25]_out0">
+                    <port-name>clk_en</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:9]_in0">
+                    <port-name>spi_sck</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:4]_in0">
+                    <port-name>rst_n</port-name>
+                </record>
+            </records>
+        </io-spec-tool>
+        <macrocell-mode-data>
+            <scene-data>
+                <scene-width>32767</scene-width>
+                <scene-height>32767</scene-height>
+                <scene-snapToGrid>1</scene-snapToGrid>
+            </scene-data>
+            <macrocells-data>
+                <macrocell>
+                    <macrocell-id>18</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input18</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>-240</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>19</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>20</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input20</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>21</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>22</macrocell-id>
+                    <macrocell-type>4</macrocell-type>
+                    <macrocell-title>NOT Gate</macrocell-title>
+                    <macrocell-name>not22</macrocell-name>
+                    <macrocell-posx>-100</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>23</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>24</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>25</macrocell-id>
+                    <macrocell-type>8</macrocell-type>
+                    <macrocell-title>NAND Gate</macrocell-title>
+                    <macrocell-name>nand25</macrocell-name>
+                    <macrocell-posx>240</macrocell-posx>
+                    <macrocell-posy>-200</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>26</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                        <port>
+                            <port-id>27</port-id>
+                            <port-index>1</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>28</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>29</macrocell-id>
+                    <macrocell-type>3</macrocell-type>
+                    <macrocell-title>OUT</macrocell-title>
+                    <macrocell-name>output29</macrocell-name>
+                    <macrocell-posx>640</macrocell-posx>
+                    <macrocell-posy>-140</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>30</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports/>
+                </macrocell>
+            </macrocells-data>
+            <wires-data>
+                <wire>
+                    <wire-id>31</wire-id>
+                    <wire-start-port-id>19</wire-start-port-id>
+                    <wire-end-port-id>26</wire-end-port-id>
+                    <wire-name>wire31</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>32</wire-id>
+                    <wire-start-port-id>21</wire-start-port-id>
+                    <wire-end-port-id>23</wire-end-port-id>
+                    <wire-name>wire32</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>33</wire-id>
+                    <wire-start-port-id>24</wire-start-port-id>
+                    <wire-end-port-id>27</wire-end-port-id>
+                    <wire-name>wire33</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>34</wire-id>
+                    <wire-start-port-id>28</wire-start-port-id>
+                    <wire-end-port-id>30</wire-end-port-id>
+                    <wire-name>wire34</wire-name>
+                </wire>
+            </wires-data>
+        </macrocell-mode-data>
+        <pllConfigurator>
+            <!--PLL configurator data-->
+            <pllConfiguratorDataVersion>1</pllConfiguratorDataVersion>
+            <pllConfigurations>
+                <pllConfiguration>
+                    <pllFref>50.000000</pllFref>
+                    <pllIsManualCalculationMode>0</pllIsManualCalculationMode>
+                    <pllOutputChannels>
+                        <pllOutputChannel>
+                            <pllIsOutEnabled>1</pllIsOutEnabled>
+                            <pllRequiredFout>50.000000</pllRequiredFout>
+                            <pllRefDiv>1</pllRefDiv>
+                            <pllFbDiv>25</pllFbDiv>
+                            <pllPostDiv1>5</pllPostDiv1>
+                            <pllPostDiv2>5</pllPostDiv2>
+                        </pllOutputChannel>
+                    </pllOutputChannels>
+                    <pllProperties>
+                        <pllBypass>0</pllBypass>
+                        <pllClockSelection>0</pllClockSelection>
+                        <pllEnableUserClockByPll>0</pllEnableUserClockByPll>
+                        <pllLock>0</pllLock>
+                    </pllProperties>
+                </pllConfiguration>
+            </pllConfigurations>
+        </pllConfigurator>
+        <!--Fpga project data END-->
+    </fpga-data>
+    <projectData>
+        <specs>
+            <lastModify lastModifyValue="13.01.2026 18:33:34"/>
+            <vddSpecs vddMin="1.05" vddTyp="1.1" vddMax="1.15"/>
+            <vdd2Specs vdd2Min="1.71" vdd2Typ="2.5" vdd2Max="3.465"/>
+            <tempSpecs tempMin="-40" tempTyp="25" tempMax="85"/>
+        </specs>
+        <projectDataFields>
+            <textLineDataField name="Customer Name" id="2" text=""/>
+            <textLineDataField name="Customer Project Name" id="3" text=""/>
+            <textLineDataField name="Customer Project Number" id="4" text=""/>
+            <textLineDataField name="Customer Version Number" id="5" text=""/>
+            <multiTextLineDataField>
+                <textLineDataField name="Notes" id="6" text=""/>
+            </multiTextLineDataField>
+        </projectDataFields>
+    </projectData>
+    <i2cTool>
+        <i2cDebugger version="1"/>
+        <i2cStepper version="1" rowCount="0"/>
+        <i2cRegsTable version="1" tabCount="0"/>
+    </i2cTool>
+<logicAnalyzer>
+    <metadata>
+        <autosavePreset>-1</autosavePreset>
+        <currentPreset>-1</currentPreset>
+        <version>3</version>
+    </metadata>
+    <presetList/>
+</logicAnalyzer>
+
+</GPDProject>

--- a/examples/Vector-8/firmware/Micropython/vector_8.py
+++ b/examples/Vector-8/firmware/Micropython/vector_8.py
@@ -1,0 +1,93 @@
+from machine import Pin, SPI
+import time
+
+# --- CONFIGURATION ---
+SCK, CS, MOSI, MISO, RST = 2, 1, 3, 0, 14
+
+# --- ISA DEFINITIONS (32-ISA) ---
+OP_NOP, OP_LDA, OP_ADD, OP_SUB = 0x00, 0x01, 0x02, 0x03
+OP_AND, OP_OR,  OP_XOR, OP_LSL = 0x04, 0x05, 0x06, 0x07
+OP_LSR, OP_ROL, OP_ROR, OP_INC = 0x08, 0x09, 0x0A, 0x0B
+OP_DEC, OP_JMP, OP_JZ,  OP_JNZ = 0x0C, 0x0D, 0x0E, 0x0F
+
+# --- INITIALIZATION ---
+reset_pin = Pin(RST, Pin.OUT, value=1)
+cs = Pin(CS, Pin.OUT, value=1)
+spi = SPI(0, baudrate=50_000, polarity=0, phase=0, bits=8, 
+          sck=Pin(SCK), mosi=Pin(MOSI), miso=Pin(MISO))
+
+def hard_reset():
+    reset_pin.value(0)
+    time.sleep(0.05)
+    reset_pin.value(1)
+    time.sleep(0.1)
+
+def send_instr(opcode, data):
+    """Sends 2-byte instruction and follows with a dummy NOP to read result."""
+    # 1. Execute Command
+    cs.value(0)
+    spi.write(bytes([opcode & 0x1F, data & 0xFF]))
+    cs.value(1)
+    
+    time.sleep_ms(2) # CPU processing time
+
+    # 2. Readback Result using NOP
+    rx = bytearray(2)
+    cs.value(0)
+    spi.write_readinto(bytes([OP_NOP, 0x00]), rx)
+    cs.value(1)
+    return rx[1] # Returning the Accumulator value
+
+def check(label, got, expected):
+    status = "PASS" if got == expected else "FAIL"
+    print(f"  [{status}] {label:25} | Got: {got:3} | Exp: {expected:3}")
+    return 1 if got == expected else 0
+
+# --- MASTER TEST SUITE ---
+def run_full_diagnostics():
+    print("Starting CPU Diagnostics...\n" + "="*50)
+    score = 0
+    total = 0
+    hard_reset()
+
+    # SECTION 1: 8-BIT BOUNDARY ARITHMETIC
+    print("\n[1] Arithmetic & Overflow")
+    score += check("LDA 255 (Max Byte)", send_instr(OP_LDA, 255), 255)
+    score += check("INC (255 -> 0 Wrap)", send_instr(OP_INC, 0), 0)
+    score += check("ADD 128", send_instr(OP_ADD, 128), 128)
+    score += check("SUB 1 (128 -> 127)", send_instr(OP_SUB, 1), 127)
+    total += 4
+
+    # SECTION 2: LOGIC & BIT MANIPULATION
+    print("\n[2] Bitwise Logic & Shifting")
+    send_instr(OP_LDA, 0x0F) # 00001111
+    score += check("AND 0x55 (0F & 55 = 05)", send_instr(OP_AND, 0x55), 0x05)
+    send_instr(OP_LDA, 0x80) # 10000000
+    score += check("ROR (Rotate Right 0x80)", send_instr(OP_ROR, 0), 0x40)
+    score += check("LSL (Shift Left 0x40)", send_instr(OP_LSL, 0), 0x80)
+    score += check("XOR 0x80 (Result 0)", send_instr(OP_XOR, 0x80), 0)
+    total += 4
+
+    # SECTION 3: FLAG SYSTEM (ZERO FLAG)
+    print("\n[3] Flag & Branch Logic")
+    # Z-flag should be set from the last XOR result (0)
+    # We test JZ by trying to 'jump' to a dummy address. 
+    # Note: In step-mode, we verify the command was accepted.
+    res = send_instr(OP_JZ, 0xAA) 
+    score += check("JZ check (Acc remains 0)", res, 0)
+    
+    # Test JNZ (should NOT take effect since Acc is 0)
+    send_instr(OP_LDA, 10)
+    res = send_instr(OP_JNZ, 0xBB)
+    score += check("JNZ check (Acc remains 10)", res, 10)
+    total += 2
+
+    print("\n" + "="*50)
+    print(f"DIAGNOSTICS COMPLETE: {score}/{total} PASSED")
+    if score == total:
+        print("RESULT: 8-BIT CORE IS FULLY FUNCTIONAL")
+    else:
+        print("RESULT: CORE HAS LOGIC ERRORS")
+
+# Execute
+run_full_diagnostics()

--- a/examples/Vector-8/src/alu_8bit.v
+++ b/examples/Vector-8/src/alu_8bit.v
@@ -1,0 +1,26 @@
+module alu_8bit (
+    input  [7:0] a_reg,
+    input  [7:0] data_in,
+    input  [4:0] opcode,
+    output reg [7:0] out,
+    output wire zero
+);
+    always @(*) begin
+        case (opcode)
+            5'h01: out = data_in;               // LDA
+            5'h02: out = a_reg + data_in;       // ADD
+            5'h03: out = a_reg - data_in;       // SUB
+            5'h04: out = a_reg & data_in;       // AND
+            5'h05: out = a_reg | data_in;       // OR
+            5'h06: out = a_reg ^ data_in;       // XOR
+            5'h07: out = a_reg << 1;            // LSL
+            5'h08: out = a_reg >> 1;            // LSR
+            5'h09: out = {a_reg[6:0], a_reg[7]};// ROL
+            5'h0A: out = {a_reg[0], a_reg[7:1]};// ROR
+            5'h0B: out = a_reg + 1'b1;          // INC
+            5'h0C: out = a_reg - 1'b1;          // DEC
+            default: out = a_reg;
+        endcase
+    end
+    assign zero = (out == 8'b0);
+endmodule

--- a/examples/Vector-8/src/cpu_core.v
+++ b/examples/Vector-8/src/cpu_core.v
@@ -1,0 +1,48 @@
+module cpu_core (
+    input  clk,
+    input  rst_n,
+    input  i_step,
+    input  [4:0] opcode,
+    input  [7:0] data_in,
+    output reg [7:0] pc,
+    output reg [7:0] acc
+);
+    wire [7:0] alu_out;
+    wire alu_zero;
+    reg  z_flag;
+
+    alu_8bit u_alu (
+        .a_reg(acc),
+        .data_in(data_in),
+        .opcode(opcode),
+        .out(alu_out),
+        .zero(alu_zero)
+    );
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            pc     <= 8'h00;
+            acc    <= 8'h00;
+            z_flag <= 1'b0;
+        end else if (i_step) begin
+            // Default: Increment PC
+            pc <= pc + 1'b1;
+
+            case (opcode)
+                // Logical/Arithmetic Group
+                5'h01, 5'h02, 5'h03, 5'h04, 5'h05, 5'h06, 
+                5'h07, 5'h08, 5'h09, 5'h0A, 5'h0B, 5'h0C: begin
+                    acc    <= alu_out;
+                    z_flag <= alu_zero;
+                end
+                
+                // Branching Group
+                5'h0D: pc <= data_in;             // JMP
+                5'h0E: if (z_flag) pc <= data_in; // JZ
+                5'h0F: if (!z_flag) pc <= data_in;// JNZ
+                
+                default: ; // NOP
+            endcase
+        end
+    end
+endmodule

--- a/examples/Vector-8/src/spi_target.v
+++ b/examples/Vector-8/src/spi_target.v
@@ -1,0 +1,118 @@
+module spi_target #(
+  parameter CPOL   = 1'b0,  // When one, clock is low in idle, otherwise clock is high
+  parameter CPHA   = 1'b0,  // When one, sampling occurs at falling edge, otherwise at rising edge of non-inverted clock
+  parameter WIDTH  = 8,     // Determines the data width of SPI to the input and output data buses
+  parameter LSB    = 1'b0   // When one, data starts from LSB, otherwise data starts from MSB 
+) (
+// common ports
+  input                  i_clk,           // input clock signal
+  input                  i_rst_n,         // input negative reset signal
+// control signal
+  input                  i_enable,        // input enable SPI target signal
+// SPI interface ports
+  input                  i_ss_n,          // input target select signal
+  input                  i_sck,           // input spi clock signal
+  input                  i_mosi,          // input controller output target input signal
+  output                 o_miso,          // output controller input target output signal
+  output                 o_miso_oe,       // output miso enable output signal
+//RX internal ports
+  output reg [WIDTH-1:0] o_rx_data,       // output data bus
+  output reg             o_rx_data_valid, // output receive data valid signal
+//TX internal ports
+  input      [WIDTH-1:0] i_tx_data,       // input data bus
+  output                 o_tx_data_hold   // output signal used to get tx data from i_tx_data input
+);
+
+// Signal declaration
+  reg               [2:0] r_ss_n_sync, r_sck_sync;
+  reg [$clog2(WIDTH-1):0] r_transmision_count;
+  reg         [WIDTH-1:0] r_miso_data;
+  wire                    w_sck_r_edge, w_sck_f_edge, w_sck_edge, w_sck_edge_op;
+
+// SPI input signals synchronization
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      r_ss_n_sync <= 'b111;
+    end else if (i_enable) begin
+      r_ss_n_sync <= {r_ss_n_sync[1:0], i_ss_n};
+    end else begin
+      r_ss_n_sync <= 'b111;
+    end
+  end
+
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      r_sck_sync <= 'h0;
+    end else if (i_enable) begin
+      r_sck_sync <= {r_sck_sync[1:0], i_sck};
+    end else begin
+      r_sck_sync <= 'h0;
+    end
+  end
+
+// Create rising and falling edge signals from spi_clk signal
+  assign w_sck_r_edge  = ~r_sck_sync[2] & r_sck_sync[1];
+  assign w_sck_f_edge  = r_sck_sync[2] & ~r_sck_sync[1];
+  assign w_sck_edge    = (CPHA^CPOL) ? w_sck_f_edge : w_sck_r_edge;
+  assign w_sck_edge_op = (CPHA^CPOL) ? w_sck_r_edge : w_sck_f_edge;
+
+// Create transmission bit counter
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      r_transmision_count <= 'h0;
+    end else if (!i_enable || r_ss_n_sync[1]) begin
+      r_transmision_count <= 'h0;
+    end else if (w_sck_edge) begin
+      if (r_transmision_count == WIDTH-1) begin
+        r_transmision_count <= 'h0;
+      end else begin
+        r_transmision_count <= r_transmision_count + 1;
+      end
+    end
+  end
+
+// Create o_rx_data bus and valid signals
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      o_rx_data <= 'h0;
+    end else if (w_sck_edge) begin
+      if (LSB) begin
+        o_rx_data <= {i_mosi, o_rx_data[WIDTH-1:1]};
+      end else begin
+        o_rx_data <= {o_rx_data[WIDTH-2:0], i_mosi};
+      end
+    end
+  end
+
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      o_rx_data_valid <= 1'b0;
+    end else if (r_ss_n_sync[1] || (r_transmision_count == 0 && w_sck_edge)) begin
+      o_rx_data_valid <= 1'b0;
+    end else if (w_sck_edge && r_transmision_count == WIDTH-1) begin
+      o_rx_data_valid <= 1'b1;
+    end
+  end
+
+// Create o_tx_data_hold signal
+  assign o_tx_data_hold = (~CPHA & r_ss_n_sync[2] & ~r_ss_n_sync[1]) | (r_transmision_count == 0 & w_sck_edge_op);
+
+// Create o_miso and OE signals
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      r_miso_data <= 'h0;
+    end else if (o_tx_data_hold) begin
+      r_miso_data <= i_tx_data;
+    end else if (w_sck_edge_op) begin
+      if (LSB) begin
+        r_miso_data <= r_miso_data >> 1;
+      end else begin
+        r_miso_data <= r_miso_data << 1;
+      end
+    end
+  end
+
+  assign o_miso    = (LSB) ? r_miso_data[0] : r_miso_data[WIDTH-1];
+  assign o_miso_oe = ~r_ss_n_sync[2];
+
+endmodule

--- a/examples/Vector-8/src/top.v
+++ b/examples/Vector-8/src/top.v
@@ -1,0 +1,69 @@
+(* top *) module top (
+    (* iopad_external_pin, clkbuf_inhibit *) input clk,
+    (* iopad_external_pin *) output clk_en,
+    (* iopad_external_pin *) input rst_n,
+
+    // SPI Interface
+    (* iopad_external_pin *) input spi_ss_n,
+    (* iopad_external_pin *) input spi_sck,
+    (* iopad_external_pin *) input spi_mosi,
+    (* iopad_external_pin *) output spi_miso,
+    (* iopad_external_pin *) output spi_miso_en
+);
+
+    assign clk_en = 1'b1;
+
+    wire [7:0] spi_rx_data;
+    wire spi_rx_valid;
+    reg  spi_rx_valid_d;
+    
+    spi_target #( .WIDTH(8) ) u_spi_target (
+        .i_clk(clk), .i_rst_n(rst_n), .i_enable(1'b1),
+        .i_ss_n(spi_ss_n), .i_sck(spi_sck), .i_mosi(spi_mosi),
+        .o_miso(spi_miso), .o_miso_oe(spi_miso_en),
+        .o_rx_data(spi_rx_data), .o_rx_data_valid(spi_rx_valid),
+        .i_tx_data(cpu_acc), .o_tx_data_hold()
+    );
+
+    reg [4:0] r_opcode;
+    reg [7:0] r_data;
+    reg byte_cnt;
+    reg step_pulse;
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            byte_cnt <= 0;
+            step_pulse <= 0;
+            spi_rx_valid_d <= 0;
+        end else begin
+            spi_rx_valid_d <= spi_rx_valid;
+            step_pulse <= 0;
+
+            if (spi_rx_valid && !spi_rx_valid_d) begin
+                if (byte_cnt == 0) begin
+                    r_opcode <= spi_rx_data[4:0]; 
+                    byte_cnt <= 1;
+                end else begin
+                    r_data <= spi_rx_data;
+                    byte_cnt <= 0;
+                    step_pulse <= 1; 
+                end
+            end
+            if (spi_ss_n) byte_cnt <= 0;
+        end
+    end
+
+    wire [7:0] cpu_pc;
+    wire [7:0] cpu_acc;
+
+    cpu_core u_cpu (
+        .clk(clk),
+        .rst_n(rst_n),
+        .i_step(step_pulse),
+        .opcode(r_opcode),
+        .data_in(r_data),
+        .pc(cpu_pc),
+        .acc(cpu_acc)
+    );
+
+endmodule


### PR DESCRIPTION
Key Features
- 8-Bit Data Width: Upgraded internal registers (Accumulator) and data buses to 8 bits, allowing for processing values from 0 to 255.
- Expanded 32-ISA: Implemented a 5-bit opcode structure supporting 32 potential instructions, including logical rotations (ROL, ROR), increment/decrement, and conditional branching (JZ, JNZ). 
- 16-Bit SPI Protocol: Optimized the communication interface to handle double-byte packets (Opcode + Operand) while simultaneously reading back the CPU state.
- Resource Efficiency: Specifically architected to fit within approximately 115–120 CLBs, leaving overhead for additional peripherals.
- Verified Hardware Integrity: Includes a comprehensive MicroPython diagnostic suite that validates the ALU, boundary conditions (overflow wrap-around), and the zero-flag logic.

Hardware Interface
The design maintains pin compatibility with existing Shrike Lite / RP2040 setups, using the standard SPI header mapping and reset logic defined in the top.v module.