### PR TITLE
Make a New Example of a 8-pin and 14-pin FPGA GPIO Extentder

### DIFF
--- a/examples/14-Pin GPIO Extender/14-pin_GPIO_extender.ffpga
+++ b/examples/14-Pin GPIO Extender/14-pin_GPIO_extender.ffpga
@@ -1,0 +1,1057 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GPDProject version="40" oldestCompatibleVersion="32" GPDVersion="6.51.001" lastChange="18 Jan 2026 00:14:21" projectChecksumState="1" projectChecksum="2c8299ac">
+    <generalProjectSettings/>
+    <chip family="04" type="06" friendlyName="FFPGA" partNumber="67" package="26">
+        <nvmData registerLenght="480">0 0 0 28 0 0 0 0 A5 A5 A5 A5 0 0 0 0 0 0 0 0 5A 5A 5A 5A 0 0 0 0 22 22 22 22 22 22 22 22 22 22 0 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</nvmData>
+        <checksum crc32="0x451C1D42" version="2"/>
+        <VDDItem id="0">
+            <item id="0" caption="VDD (PIN 22)">
+                <graphics pos="(1350.00,143.10)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <VDDItem id="1">
+            <item id="1" caption="VDDIO (PIN 21)">
+                <graphics pos="(1350.00,226.67)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <item id="2" caption="GND (PIN 12)">
+            <graphics pos="(1350.00,298.48)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="3" caption="FPGA">
+            <graphics pos="(0.00,0.00)" angle="0" flipping="0" hidden="0" tOrigin="(640.00,442.50)"/>
+        </item>
+        <item id="4" caption="GPIO0 (PIN 13)">
+            <graphics pos="(35.00,592.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="5" caption="GPIO1 (PIN 14)">
+            <graphics pos="(150.00,542.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="6" caption="GPIO2 (PIN 15)">
+            <graphics pos="(35.00,493.59)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="7" caption="GPIO3 (PIN 16)">
+            <graphics pos="(150.00,444.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="8" caption="GPIO4 (PIN 17)">
+            <graphics pos="(35.00,394.74)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="9" caption="GPIO5 (PIN 18)">
+            <graphics pos="(35.00,197.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="10" caption="GPIO6 (PIN 19)">
+            <graphics pos="(150.00,148.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="11" caption="GPIO7 (PIN 20)">
+            <graphics pos="(35.00,98.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="12" caption="GPIO8 (PIN 23)">
+            <graphics pos="(1094.00,49.99)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="13" caption="GPIO9 (PIN 24)">
+            <graphics pos="(1200.00,102.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="14" caption="GPIO10 (PIN 1)">
+            <graphics pos="(1094.00,154.03)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="15" caption="GPIO11 (PIN 2)">
+            <graphics pos="(1200.00,206.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="16" caption="GPIO12 (PIN 3)">
+            <graphics pos="(1094.00,258.20)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="17" caption="GPIO13 (PIN 4)">
+            <graphics pos="(1200.00,310.28)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="18" caption="GPIO14 (PIN 5)">
+            <graphics pos="(1094.00,397.09)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="19" caption="GPIO15 (PIN 6)">
+            <graphics pos="(1200.00,449.75)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="20" caption="GPIO18 (PIN 9/GrP0)">
+            <graphics pos="(1094.00,604.84)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="21" caption="GPIO17 (PIN 8/GrP1)">
+            <graphics pos="(1200.00,553.34)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="22" caption="GPIO16 (PIN 7/GrP2)">
+            <graphics pos="(1094.00,501.25)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="23" caption="nRST (PIN 11)">
+            <graphics pos="(1094.00,356.17)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="24" caption="nSLEEP (PIN 10)">
+            <graphics pos="(1200.00,374.22)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="25" caption="OSC">
+            <graphics pos="(150.00,64.53)" angle="0" flipping="0" hidden="0" tOrigin="(25.00,10.00)"/>
+        </item>
+        <item id="26" caption="Phase-Locked Loop">
+            <graphics pos="(149.73,246.87)" angle="180" flipping="0" hidden="0" tOrigin="(25.00,70.00)"/>
+        </item>
+        <item id="27" caption="BRAM">
+            <graphics pos="(616.77,701.83)" angle="90" flipping="0" hidden="0" tOrigin="(25.00,100.00)"/>
+        </item>
+        <item id="28" caption="FPGA Core">
+            <graphics pos="(340.90,49.43)" angle="0" flipping="0" hidden="0" tOrigin="(300.00,300.00)"/>
+        </item>
+        <wire output="79" input="65" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (236.00,80.00); (236.00,250.00); (220.00,250.00)</points>
+        </wire>
+        <wire output="2" input="66" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (226.00,510.00); (226.00,383.00); (220.00,383.00)</points>
+        </wire>
+        <wire output="83" input="85" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="0" wireText="NET0" wireState="0">
+            <points>(129.00,344.00); (116.00,344.00); (116.00,392.00); (308.00,392.00); (308.00,383.00); (320.00,383.00)</points>
+        </wire>
+        <wire output="84" input="86" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="1" wireText="NET1" wireState="0">
+            <points>(711.00,669.00); (711.00,756.00)</points>
+        </wire>
+        <wire output="85" input="87" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="2" wireText="NET2" wireState="0">
+            <points>(726.00,669.00); (726.00,756.00)</points>
+        </wire>
+        <wire output="86" input="88" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="3" wireText="NET3" wireState="0">
+            <points>(220.00,70.00); (320.00,70.00)</points>
+        </wire>
+        <wire output="79" input="38" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (314.00,80.00); (314.00,87.00); (320.00,87.00)</points>
+        </wire>
+        <wire output="39" input="63" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="5" wireText="NET5" wireState="0">
+            <points>(320.00,54.00); (116.00,54.00); (116.00,75.00); (129.00,75.00)</points>
+        </wire>
+        <wire output="20" input="62" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="6" wireText="NET6" wireState="0">
+            <points>(1177.00,384.00); (967.00,384.00); (967.00,385.00); (961.00,385.00)</points>
+        </wire>
+        <wire output="19" input="61" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="7" wireText="NET7" wireState="0">
+            <points>(1071.00,366.00); (967.00,366.00); (967.00,367.00); (961.00,367.00)</points>
+        </wire>
+        <wire output="82" input="41" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="8" wireText="NET8" wireState="0">
+            <points>(642.00,847.00); (642.00,853.00); (308.00,853.00); (308.00,645.00); (320.00,645.00)</points>
+        </wire>
+        <wire output="21" input="75" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="9" wireText="NET9" wireState="0">
+            <points>(557.00,669.00); (557.00,756.00)</points>
+        </wire>
+        <wire output="25" input="76" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="10" wireText="NET10" wireState="0">
+            <points>(618.00,669.00); (618.00,756.00)</points>
+        </wire>
+        <wire output="22" input="77" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="11" wireText="NET11" wireState="0">
+            <points>(573.00,669.00); (573.00,756.00)</points>
+        </wire>
+        <wire output="23" input="78" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="12" wireText="NET12" wireState="0">
+            <points>(588.00,669.00); (588.00,756.00)</points>
+        </wire>
+        <wire output="26" input="79" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="13" wireText="NET13" wireState="0">
+            <points>(634.00,669.00); (634.00,756.00)</points>
+        </wire>
+        <wire output="27" input="80" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="14" wireText="NET14" wireState="0">
+            <points>(649.00,669.00); (649.00,756.00)</points>
+        </wire>
+        <wire output="28" input="81" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="15" wireText="NET15" wireState="0">
+            <points>(664.00,669.00); (664.00,756.00)</points>
+        </wire>
+        <wire output="24" input="82" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="16" wireText="NET16" wireState="0">
+            <points>(603.00,669.00); (603.00,756.00)</points>
+        </wire>
+        <wire output="29" input="83" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="17" wireText="NET17" wireState="0">
+            <points>(680.00,669.00); (680.00,756.00)</points>
+        </wire>
+        <wire output="30" input="84" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="18" wireText="NET18" wireState="0">
+            <points>(695.00,669.00); (695.00,756.00)</points>
+        </wire>
+        <wire output="80" input="39" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="20" wireText="NET20" wireState="0">
+            <points>(129.00,289.00); (116.00,289.00); (116.00,240.00); (308.00,240.00); (308.00,251.00); (320.00,251.00)</points>
+        </wire>
+        <wire output="34" input="67" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="21" wireText="NET21" wireState="0">
+            <points>(320.00,333.00); (220.00,333.00)</points>
+        </wire>
+        <wire output="38" input="68" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="22" wireText="NET22" wireState="0">
+            <points>(320.00,267.00); (220.00,267.00)</points>
+        </wire>
+        <wire output="37" input="69" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="23" wireText="NET23" wireState="0">
+            <points>(320.00,284.00); (220.00,284.00)</points>
+        </wire>
+        <wire output="36" input="70" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="24" wireText="NET24" wireState="0">
+            <points>(320.00,300.00); (220.00,300.00)</points>
+        </wire>
+        <wire output="35" input="71" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="25" wireText="NET25" wireState="0">
+            <points>(320.00,317.00); (220.00,317.00)</points>
+        </wire>
+        <wire output="33" input="72" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="26" wireText="NET26" wireState="0">
+            <points>(320.00,350.00); (220.00,350.00)</points>
+        </wire>
+        <wire output="32" input="73" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="27" wireText="NET27" wireState="0">
+            <points>(320.00,366.00); (220.00,366.00)</points>
+        </wire>
+        <wire output="41" input="0" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="28" wireText="NET28" wireState="0">
+            <points>(320.00,597.00); (97.00,597.00)</points>
+        </wire>
+        <wire output="42" input="1" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="29" wireText="NET29" wireState="0">
+            <points>(320.00,547.00); (212.00,547.00)</points>
+        </wire>
+        <wire output="43" input="2" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="30" wireText="NET30" wireState="0">
+            <points>(320.00,498.00); (97.00,498.00)</points>
+        </wire>
+        <wire output="44" input="3" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="31" wireText="NET31" wireState="0">
+            <points>(320.00,449.00); (212.00,449.00)</points>
+        </wire>
+        <wire output="45" input="4" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="32" wireText="NET32" wireState="0">
+            <points>(320.00,399.00); (97.00,399.00)</points>
+        </wire>
+        <wire output="46" input="5" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="33" wireText="NET33" wireState="0">
+            <points>(320.00,202.00); (97.00,202.00)</points>
+        </wire>
+        <wire output="47" input="6" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="34" wireText="NET34" wireState="0">
+            <points>(320.00,153.00); (212.00,153.00)</points>
+        </wire>
+        <wire output="48" input="7" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="35" wireText="NET35" wireState="0">
+            <points>(320.00,103.00); (97.00,103.00)</points>
+        </wire>
+        <wire output="49" input="8" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="36" wireText="NET36" wireState="0">
+            <points>(961.00,55.00); (1071.00,55.00)</points>
+        </wire>
+        <wire output="50" input="9" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="37" wireText="NET37" wireState="0">
+            <points>(961.00,107.00); (1177.00,107.00)</points>
+        </wire>
+        <wire output="51" input="10" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="38" wireText="NET38" wireState="0">
+            <points>(961.00,159.00); (1071.00,159.00)</points>
+        </wire>
+        <wire output="52" input="11" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="39" wireText="NET39" wireState="0">
+            <points>(961.00,211.00); (1177.00,211.00)</points>
+        </wire>
+        <wire output="53" input="12" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="40" wireText="NET40" wireState="0">
+            <points>(961.00,263.00); (1071.00,263.00)</points>
+        </wire>
+        <wire output="54" input="13" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="41" wireText="NET41" wireState="0">
+            <points>(961.00,315.00); (1177.00,315.00)</points>
+        </wire>
+        <wire output="55" input="14" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="42" wireText="NET42" wireState="0">
+            <points>(961.00,402.00); (1071.00,402.00)</points>
+        </wire>
+        <wire output="56" input="15" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="43" wireText="NET43" wireState="0">
+            <points>(961.00,454.00); (1177.00,454.00)</points>
+        </wire>
+        <wire output="57" input="16" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="44" wireText="NET44" wireState="0">
+            <points>(961.00,610.00); (1071.00,610.00)</points>
+        </wire>
+        <wire output="58" input="17" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="45" wireText="NET45" wireState="0">
+            <points>(961.00,558.00); (1177.00,558.00)</points>
+        </wire>
+        <wire output="59" input="18" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="46" wireText="NET46" wireState="0">
+            <points>(961.00,506.00); (1071.00,506.00)</points>
+        </wire>
+        <wire output="60" input="19" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="47" wireText="NET47" wireState="0">
+            <points>(320.00,630.00); (108.00,630.00); (108.00,648.00); (54.00,648.00); (54.00,633.00)</points>
+        </wire>
+        <wire output="61" input="20" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="48" wireText="NET48" wireState="0">
+            <points>(320.00,580.00); (220.00,580.00); (220.00,588.00); (169.00,588.00); (169.00,582.00)</points>
+        </wire>
+        <wire output="62" input="21" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="49" wireText="NET49" wireState="0">
+            <points>(320.00,531.00); (108.00,531.00); (108.00,552.00); (54.00,552.00); (54.00,534.00)</points>
+        </wire>
+        <wire output="63" input="22" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="50" wireText="NET50" wireState="0">
+            <points>(320.00,482.00); (220.00,482.00); (220.00,490.00); (169.00,490.00); (169.00,484.00)</points>
+        </wire>
+        <wire output="64" input="23" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="51" wireText="NET51" wireState="0">
+            <points>(320.00,432.00); (108.00,432.00); (108.00,448.00); (54.00,448.00); (54.00,435.00)</points>
+        </wire>
+        <wire output="65" input="24" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="52" wireText="NET52" wireState="0">
+            <points>(320.00,235.00); (108.00,235.00); (108.00,248.00); (54.00,248.00); (54.00,237.00)</points>
+        </wire>
+        <wire output="66" input="25" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="53" wireText="NET53" wireState="0">
+            <points>(320.00,185.00); (220.00,185.00); (220.00,194.00); (169.00,194.00); (169.00,188.00)</points>
+        </wire>
+        <wire output="67" input="26" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="54" wireText="NET54" wireState="0">
+            <points>(320.00,136.00); (108.00,136.00); (108.00,152.00); (54.00,152.00); (54.00,139.00)</points>
+        </wire>
+        <wire output="68" input="27" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="55" wireText="NET55" wireState="0">
+            <points>(961.00,90.00); (1060.00,90.00); (1060.00,96.00); (1113.00,96.00); (1113.00,90.00)</points>
+        </wire>
+        <wire output="69" input="28" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="56" wireText="NET56" wireState="0">
+            <points>(961.00,142.00); (1172.00,142.00); (1172.00,160.00); (1219.00,160.00); (1219.00,142.00)</points>
+        </wire>
+        <wire output="70" input="29" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="57" wireText="NET57" wireState="0">
+            <points>(961.00,194.00); (1060.00,194.00); (1060.00,200.00); (1113.00,200.00); (1113.00,194.00)</points>
+        </wire>
+        <wire output="71" input="30" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="58" wireText="NET58" wireState="0">
+            <points>(961.00,246.00); (1172.00,246.00); (1172.00,264.00); (1219.00,264.00); (1219.00,246.00)</points>
+        </wire>
+        <wire output="72" input="31" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="59" wireText="NET59" wireState="0">
+            <points>(961.00,298.00); (1060.00,298.00); (1060.00,304.00); (1113.00,304.00); (1113.00,298.00)</points>
+        </wire>
+        <wire output="73" input="32" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="60" wireText="NET60" wireState="0">
+            <points>(961.00,350.00); (1172.00,350.00); (1172.00,356.00); (1219.00,356.00); (1219.00,350.00)</points>
+        </wire>
+        <wire output="74" input="33" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="61" wireText="NET61" wireState="0">
+            <points>(961.00,437.00); (1060.00,437.00); (1060.00,443.00); (1113.00,443.00); (1113.00,437.00)</points>
+        </wire>
+        <wire output="75" input="34" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="62" wireText="NET62" wireState="0">
+            <points>(961.00,489.00); (1172.00,489.00); (1172.00,504.00); (1219.00,504.00); (1219.00,490.00)</points>
+        </wire>
+        <wire output="76" input="35" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="63" wireText="NET63" wireState="0">
+            <points>(961.00,645.00); (1060.00,645.00); (1060.00,664.00); (1113.00,664.00); (1113.00,645.00)</points>
+        </wire>
+        <wire output="77" input="36" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="64" wireText="NET64" wireState="0">
+            <points>(961.00,593.00); (1172.00,593.00); (1172.00,608.00); (1219.00,608.00); (1219.00,593.00)</points>
+        </wire>
+        <wire output="78" input="37" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="65" wireText="NET65" wireState="0">
+            <points>(961.00,541.00); (1060.00,541.00); (1060.00,547.00); (1113.00,547.00); (1113.00,541.00)</points>
+        </wire>
+        <wire output="0" input="42" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="66" wireText="NET66" wireState="0">
+            <points>(97.00,609.00); (314.00,609.00); (314.00,613.00); (320.00,613.00)</points>
+        </wire>
+        <wire output="1" input="43" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="67" wireText="NET67" wireState="0">
+            <points>(212.00,558.00); (314.00,558.00); (314.00,564.00); (320.00,564.00)</points>
+        </wire>
+        <wire output="2" input="44" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (314.00,510.00); (314.00,514.00); (320.00,514.00)</points>
+        </wire>
+        <wire output="3" input="45" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="68" wireText="NET68" wireState="0">
+            <points>(212.00,460.00); (314.00,460.00); (314.00,465.00); (320.00,465.00)</points>
+        </wire>
+        <wire output="4" input="46" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="69" wireText="NET69" wireState="0">
+            <points>(97.00,411.00); (314.00,411.00); (314.00,416.00); (320.00,416.00)</points>
+        </wire>
+        <wire output="5" input="47" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="70" wireText="NET70" wireState="0">
+            <points>(97.00,213.00); (314.00,213.00); (314.00,218.00); (320.00,218.00)</points>
+        </wire>
+        <wire output="6" input="48" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="71" wireText="NET71" wireState="0">
+            <points>(212.00,164.00); (314.00,164.00); (314.00,169.00); (320.00,169.00)</points>
+        </wire>
+        <wire output="7" input="49" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="72" wireText="NET72" wireState="0">
+            <points>(97.00,115.00); (314.00,115.00); (314.00,120.00); (320.00,120.00)</points>
+        </wire>
+        <wire output="8" input="50" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="73" wireText="NET73" wireState="0">
+            <points>(1071.00,66.00); (967.00,66.00); (967.00,72.00); (961.00,72.00)</points>
+        </wire>
+        <wire output="9" input="51" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="74" wireText="NET74" wireState="0">
+            <points>(1177.00,118.00); (967.00,118.00); (967.00,124.00); (961.00,124.00)</points>
+        </wire>
+        <wire output="10" input="52" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="75" wireText="NET75" wireState="0">
+            <points>(1071.00,170.00); (967.00,170.00); (967.00,176.00); (961.00,176.00)</points>
+        </wire>
+        <wire output="11" input="53" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="76" wireText="NET76" wireState="0">
+            <points>(1177.00,222.00); (967.00,222.00); (967.00,228.00); (961.00,228.00)</points>
+        </wire>
+        <wire output="12" input="54" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="77" wireText="NET77" wireState="0">
+            <points>(1071.00,275.00); (967.00,275.00); (967.00,280.00); (961.00,280.00)</points>
+        </wire>
+        <wire output="13" input="55" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="78" wireText="NET78" wireState="0">
+            <points>(1177.00,327.00); (967.00,327.00); (967.00,333.00); (961.00,333.00)</points>
+        </wire>
+        <wire output="14" input="56" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="79" wireText="NET79" wireState="0">
+            <points>(1071.00,413.00); (967.00,413.00); (967.00,419.00); (961.00,419.00)</points>
+        </wire>
+        <wire output="15" input="57" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="80" wireText="NET80" wireState="0">
+            <points>(1177.00,466.00); (967.00,466.00); (967.00,471.00); (961.00,471.00)</points>
+        </wire>
+        <wire output="16" input="58" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="81" wireText="NET81" wireState="0">
+            <points>(1071.00,621.00); (967.00,621.00); (967.00,628.00); (961.00,628.00)</points>
+        </wire>
+        <wire output="17" input="59" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="82" wireText="NET82" wireState="0">
+            <points>(1177.00,570.00); (967.00,570.00); (967.00,576.00); (961.00,576.00)</points>
+        </wire>
+        <wire output="18" input="60" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="83" wireText="NET83" wireState="0">
+            <points>(1071.00,518.00); (967.00,518.00); (967.00,524.00); (961.00,524.00)</points>
+        </wire>
+    </chip>
+    <emulatorConfiguration version="4" oldestCompatibleVersion="4">
+        <settings>
+            <autoApply value="0"/>
+            <platformSelector id="-1"/>
+        </settings>
+        <platform id="0" friendlyName="GreenPAK DIP Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="1" friendlyName="GreenPAK Advanced Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="2" friendlyName="GreenPAK Pro Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="4" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="5" friendlyName="GreenPAK Advanced Development Platform w/ Logic Level Adapter #1">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="6" friendlyName="ForgeFPGA Deluxe Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="7" friendlyName="ForgeFPGA Evaluation Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="8" friendlyName="SLG51000 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="9" friendlyName="SLG51001 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="10" friendlyName="SLG51002 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="11" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="12" friendlyName="GreenPAK Lite Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="13" friendlyName="HVPAK Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="14" friendlyName="SLG47105V Training Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="15" friendlyName="Power GreenPAK Development Motherboard">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="16" friendlyName="ForgeFPGA Deluxe Development Platform Rev. 2.0">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="17" friendlyName="HVPAK SLG47125 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="18" friendlyName="Go Configure Development Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="19" friendlyName="HVPAK SLG47125 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="20" friendlyName="Go Configure Development Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+    </emulatorConfiguration>
+    <fpga-data>
+        <!--Fpga project data-->
+        <project-data-version>7</project-data-version>
+        <oldestCompatibleVersion>6</oldestCompatibleVersion>
+        <settings>
+            <generateBitstream>
+                <MAX_CPU>16</MAX_CPU>
+                <additionalArguments></additionalArguments>
+                <clockConcurrentOptimization>true</clockConcurrentOptimization>
+                <compilerVersion>23</compilerVersion>
+                <highDensityIOPacking>false</highDensityIOPacking>
+                <highDensityPackingLogic>true</highDensityPackingLogic>
+                <maximumRoutingIterations>300</maximumRoutingIterations>
+                <placeAndTrialRoute>false</placeAndTrialRoute>
+                <placeAndTrialRouteIterationCount>20</placeAndTrialRouteIterationCount>
+                <timingAnalysisCorner>0</timingAnalysisCorner>
+            </generateBitstream>
+            <simulation>
+                <wavedumpOutputFormat>1</wavedumpOutputFormat>
+            </simulation>
+            <synthesize>
+                <additionalArguments></additionalArguments>
+                <enableHardMultiplexerResources>true</enableHardMultiplexerResources>
+                <flatten>true</flatten>
+                <keep>false</keep>
+                <multiplexerResourcesNumber>5</multiplexerResourcesNumber>
+                <noDSP>true</noDSP>
+                <useABC9>true</useABC9>
+            </synthesize>
+        </settings>
+        <openedTabs>
+            <openedTab>main.v</openedTab>
+            <openedTab>spi_target.v</openedTab>
+            <openedTab>I/O Planner</openedTab>
+        </openedTabs>
+        <pipelineStagesStates>
+            <pipelineStageState>
+                <pipelineStage>0</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+            <pipelineStageState>
+                <pipelineStage>1</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+        </pipelineStagesStates>
+        <modules>
+            <scr>
+                <module filename="main.v"/>
+                <module filename="spi_target.v"/>
+            </scr>
+            <lib/>
+            <sim/>
+            <netlists/>
+            <timing-constraints/>
+            <full-chip-simulation-models/>
+            <placement-constraints/>
+        </modules>
+        <io-spec-tool>
+            <records filter="16">
+                <record id="CLK_t[0:0]_W_in0">
+                    <port-name>clk</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:10]_in0">
+                    <port-name>spi_ss_n</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:22]_in0">
+                    <port-name>spi_mosi</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:23]_out0">
+                    <port-name>spi_miso</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:23]_out1">
+                    <port-name>spi_miso_en</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:24]_in0">
+                    <port-name>i_gpio_pins[3]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:24]_out0">
+                    <port-name>o_gpio_pins[3]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:24]_out1">
+                    <port-name>o_gpio_en[3]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:25]_out0">
+                    <port-name>clk_en</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:6]_in0">
+                    <port-name>i_gpio_pins[0]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:6]_out0">
+                    <port-name>o_gpio_pins[0]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:6]_out1">
+                    <port-name>o_gpio_en[0]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:7]_in0">
+                    <port-name>i_gpio_pins[1]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:7]_out0">
+                    <port-name>o_gpio_pins[1]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:7]_out1">
+                    <port-name>o_gpio_en[1]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:8]_in0">
+                    <port-name>i_gpio_pins[2]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:8]_out0">
+                    <port-name>o_gpio_pins[2]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:8]_out1">
+                    <port-name>o_gpio_en[2]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:9]_in0">
+                    <port-name>spi_sck</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:22]_in0">
+                    <port-name>i_gpio_pins[9]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:22]_out0">
+                    <port-name>o_gpio_pins[9]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:22]_out1">
+                    <port-name>o_gpio_en[9]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:23]_in0">
+                    <port-name>i_gpio_pins[8]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:23]_out0">
+                    <port-name>o_gpio_pins[8]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:23]_out1">
+                    <port-name>o_gpio_en[8]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:24]_in0">
+                    <port-name>i_gpio_pins[7]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:24]_out0">
+                    <port-name>o_gpio_pins[7]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:24]_out1">
+                    <port-name>o_gpio_en[7]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:25]_in0">
+                    <port-name>i_gpio_pins[6]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:25]_out0">
+                    <port-name>o_gpio_pins[6]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:25]_out1">
+                    <port-name>o_gpio_en[6]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:26]_in0">
+                    <port-name>i_gpio_pins[5]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:26]_out0">
+                    <port-name>o_gpio_pins[5]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:26]_out1">
+                    <port-name>o_gpio_en[5]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:27]_in0">
+                    <port-name>i_gpio_pins[4]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:27]_out0">
+                    <port-name>o_gpio_pins[4]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:27]_out1">
+                    <port-name>o_gpio_en[4]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:4]_in0">
+                    <port-name>i_gpio_pins[13]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:4]_out0">
+                    <port-name>o_gpio_pins[13]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:4]_out1">
+                    <port-name>o_gpio_en[13]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:5]_in0">
+                    <port-name>i_gpio_pins[12]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:5]_out0">
+                    <port-name>o_gpio_pins[12]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:5]_out1">
+                    <port-name>o_gpio_en[12]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:6]_in0">
+                    <port-name>rst_n</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:8]_in0">
+                    <port-name>i_gpio_pins[11]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:8]_out0">
+                    <port-name>o_gpio_pins[11]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:8]_out1">
+                    <port-name>o_gpio_en[11]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:9]_in0">
+                    <port-name>i_gpio_pins[10]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:9]_out0">
+                    <port-name>o_gpio_pins[10]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:9]_out1">
+                    <port-name>o_gpio_en[10]</port-name>
+                </record>
+            </records>
+        </io-spec-tool>
+        <macrocell-mode-data>
+            <scene-data>
+                <scene-width>32767</scene-width>
+                <scene-height>32767</scene-height>
+                <scene-snapToGrid>1</scene-snapToGrid>
+            </scene-data>
+            <macrocells-data>
+                <macrocell>
+                    <macrocell-id>18</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input18</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>-240</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>19</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>20</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input20</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>21</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>22</macrocell-id>
+                    <macrocell-type>4</macrocell-type>
+                    <macrocell-title>NOT Gate</macrocell-title>
+                    <macrocell-name>not22</macrocell-name>
+                    <macrocell-posx>-100</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>23</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>24</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>25</macrocell-id>
+                    <macrocell-type>8</macrocell-type>
+                    <macrocell-title>NAND Gate</macrocell-title>
+                    <macrocell-name>nand25</macrocell-name>
+                    <macrocell-posx>240</macrocell-posx>
+                    <macrocell-posy>-200</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>26</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                        <port>
+                            <port-id>27</port-id>
+                            <port-index>1</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>28</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>29</macrocell-id>
+                    <macrocell-type>3</macrocell-type>
+                    <macrocell-title>OUT</macrocell-title>
+                    <macrocell-name>output29</macrocell-name>
+                    <macrocell-posx>640</macrocell-posx>
+                    <macrocell-posy>-140</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>30</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports/>
+                </macrocell>
+            </macrocells-data>
+            <wires-data>
+                <wire>
+                    <wire-id>31</wire-id>
+                    <wire-start-port-id>19</wire-start-port-id>
+                    <wire-end-port-id>26</wire-end-port-id>
+                    <wire-name>wire31</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>32</wire-id>
+                    <wire-start-port-id>21</wire-start-port-id>
+                    <wire-end-port-id>23</wire-end-port-id>
+                    <wire-name>wire32</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>33</wire-id>
+                    <wire-start-port-id>24</wire-start-port-id>
+                    <wire-end-port-id>27</wire-end-port-id>
+                    <wire-name>wire33</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>34</wire-id>
+                    <wire-start-port-id>28</wire-start-port-id>
+                    <wire-end-port-id>30</wire-end-port-id>
+                    <wire-name>wire34</wire-name>
+                </wire>
+            </wires-data>
+        </macrocell-mode-data>
+        <pllConfigurator>
+            <!--PLL configurator data-->
+            <pllConfiguratorDataVersion>1</pllConfiguratorDataVersion>
+            <pllConfigurations>
+                <pllConfiguration>
+                    <pllFref>50.000000</pllFref>
+                    <pllIsManualCalculationMode>0</pllIsManualCalculationMode>
+                    <pllOutputChannels>
+                        <pllOutputChannel>
+                            <pllIsOutEnabled>1</pllIsOutEnabled>
+                            <pllRequiredFout>50.000000</pllRequiredFout>
+                            <pllRefDiv>1</pllRefDiv>
+                            <pllFbDiv>25</pllFbDiv>
+                            <pllPostDiv1>5</pllPostDiv1>
+                            <pllPostDiv2>5</pllPostDiv2>
+                        </pllOutputChannel>
+                    </pllOutputChannels>
+                    <pllProperties>
+                        <pllBypass>0</pllBypass>
+                        <pllClockSelection>0</pllClockSelection>
+                        <pllEnableUserClockByPll>0</pllEnableUserClockByPll>
+                        <pllLock>0</pllLock>
+                    </pllProperties>
+                </pllConfiguration>
+            </pllConfigurations>
+        </pllConfigurator>
+        <!--Fpga project data END-->
+    </fpga-data>
+    <projectData>
+        <specs>
+            <lastModify lastModifyValue="17.01.2026 11:39:53"/>
+            <vddSpecs vddMin="1.05" vddTyp="1.1" vddMax="1.15"/>
+            <vdd2Specs vdd2Min="1.71" vdd2Typ="2.5" vdd2Max="3.465"/>
+            <tempSpecs tempMin="-40" tempTyp="25" tempMax="85"/>
+        </specs>
+        <projectDataFields>
+            <textLineDataField name="Customer Name" id="2" text=""/>
+            <textLineDataField name="Customer Project Name" id="3" text=""/>
+            <textLineDataField name="Customer Project Number" id="4" text=""/>
+            <textLineDataField name="Customer Version Number" id="5" text=""/>
+            <multiTextLineDataField>
+                <textLineDataField name="Notes" id="6" text=""/>
+            </multiTextLineDataField>
+        </projectDataFields>
+    </projectData>
+    <i2cTool>
+        <i2cDebugger version="1"/>
+        <i2cStepper version="1" rowCount="0"/>
+        <i2cRegsTable version="1" tabCount="0"/>
+    </i2cTool>
+<logicAnalyzer>
+    <metadata>
+        <autosavePreset>-1</autosavePreset>
+        <currentPreset>-1</currentPreset>
+        <version>3</version>
+    </metadata>
+    <presetList/>
+</logicAnalyzer>
+
+</GPDProject>

--- a/examples/14-Pin GPIO Extender/README.md
+++ b/examples/14-Pin GPIO Extender/README.md
@@ -1,0 +1,162 @@
+# Shrike-GPIO-14: 14-Bit FPGA I/O Expander
+
+This project implements a custom **14-bit Bi-directional GPIO Expander** on the Vicharak **Shrike Lite** board. By leveraging the FPGA's logic fabric, this design allows the RP2040/RP2350 to control **14 additional independent pins** via a high-speed **SPI interface**. The FPGA pins support dynamic direction switching (Input/Output) and full read/write operations, effectively turning the FPGA into a versatile I/O expansion peripheral with nearly double the capacity of the 8-bit version.
+
+---
+
+## System Architecture
+
+The system functions as a soft-command bridge between the microcontroller and the FPGA:
+
+* **RP2040/RP2350 (Master):** Executes MicroPython firmware to send commands and read pin states over SPI.
+* **FPGA (Slave):** Contains a custom GPIO architecture that manages internal registers and physical tristate buffers.
+
+### Specifications
+
+| Feature | Detail |
+| :--- | :--- |
+| **I/O Width** | 14 Independent Bi-directional Pins |
+| **Interface** | SPI with 2-byte command protocol |
+| **Data Transfer** | Multi-byte read support (high byte + low byte) |
+| **Clocking** | Internal 50MHz Oscillator |
+| **Logic Type** | Memory-mapped Register Control |
+| **Max Speed** | 1 MHz SPI (tested), higher speeds possible |
+
+---
+
+## The SPI Protocol
+
+The 14-bit GPIO system uses a **2-byte command protocol** for writes and a **2-byte read protocol** for reading all GPIO states.
+
+### Write Operations (RP2040 -> FPGA)
+
+Each write consists of **2 consecutive bytes**: Command Byte + Data Byte
+
+| Command Byte | Function | Data Byte Format | Description |
+| :---: | :--- | :--- | :--- |
+| `0x10` | **Lower DIR** | `[7:0]` = Direction bits [7:0] | Set directions for pins 0-7 (1=Input, 0=Output) |
+| `0x11` | **Upper DIR** | `[5:0]` = Direction bits [13:8] | Set directions for pins 8-13 (1=Input, 0=Output) |
+| `0x20` | **Lower DATA** | `[7:0]` = Output data [7:0] | Drive logic levels for pins 0-7 |
+| `0x21` | **Upper DATA** | `[5:0]` = Output data [13:8] | Drive logic levels for pins 8-13 |
+
+**Example:** To set pins 0-7 as outputs and write `0xAA`:
+```python
+fpga.spi.write(bytes([0x10, 0x00]))  # Set pins 0-7 as outputs
+fpga.spi.write(bytes([0x20, 0xAA]))  # Write 0xAA to pins 0-7
+```
+
+### Read Operations (FPGA -> RP2040)
+
+Reading the GPIO state requires **2 separate SPI byte transfers** with delays between them:
+
+1. **First transfer:** Reads high byte `[13:8]` (6 bits + 2 padding bits)
+2. **Second transfer:** Reads low byte `[7:0]`
+
+The FPGA automatically alternates between sending the high byte and low byte on consecutive transfers within the same CS transaction.
+
+**Example MicroPython read:**
+```python
+cs.value(0)
+time.sleep_us(20)
+high_byte = spi.read(1, 0x00)[0]  # Read bits [13:8]
+time.sleep_us(20)
+low_byte = spi.read(1, 0x00)[0]   # Read bits [7:0]
+time.sleep_us(20)
+cs.value(1)
+
+gpio_state = low_byte | ((high_byte & 0x3F) << 8)
+```
+
+---
+
+## Hardware Connections
+
+This design utilizes specific synthesis attributes (`iopad_external_pin`, `clkbuf_inhibit`) to ensure the Renesas ForgeFPGA hardware maps the logic correctly to the physical pads.
+
+### Top Module Interface
+
+These signals correspond to the top-level Verilog module (`top.v`):
+
+| Signal | Direction | Description |
+| :--- | :--- | :--- |
+| `clk` | In | Internal 50 MHz Oscillator |
+| `clk_en` | Out | OSC Enable (tied to `1'b1`) |
+| `rst_n` | In | System Reset (Active Low) |
+| `spi_ss_n` | In | SPI Slave Select (Active Low) |
+| `spi_sck` | In | SPI Clock |
+| `spi_mosi` | In | Master Out Slave In |
+| `spi_miso` | Out | Master In Slave Out |
+| `spi_miso_en` | Out | MISO Tristate Enable |
+
+### SPI Pin Mapping
+
+| Signal Function | FPGA Pin (Label) | RP2040/RP2350 Pin | Direction |
+| :--- | :---: | :---: | :--- |
+| **SPI Clock** | GPIO03 (Pin 2) | GPIO 2 | RP2040 -> FPGA |
+| **Chip Select** | GPIO04 (Pin 17) | GPIO 1 | RP2040 -> FPGA |
+| **MOSI** | GPIO05 (Pin 18) | GPIO 3 | RP2040 -> FPGA |
+| **MISO** | GPIO06 (Pin 19) | GPIO 0 | FPGA -> RP2040 |
+| **Reset** | GPIO16 (Pin 7) | (Connected via hardware) | System Reset |
+
+### Target GPIO Mapping (14 Pins)
+
+Each bit is mapped to its own physical GPIO resource in the I/O Planner:
+
+| GPIO Bit | FPGA Internal Label | Physical Pin | Register Bit |
+| :---: | :---: | :---: | :---: |
+| 0 | GPIO0 | 13 | `gpio_out_reg[0]` |
+| 1 | GPIO1 | 14 | `gpio_out_reg[1]` |
+| 2 | GPIO2 | 15 | `gpio_out_reg[2]` |
+| 3 | GPIO7 | 20 | `gpio_out_reg[3]` |
+| 4 | GPIO8 | 23 | `gpio_out_reg[4]` |
+| 5 | GPIO9 | 24 | `gpio_out_reg[5]` |
+| 6 | GPIO10 | 1 | `gpio_out_reg[6]` |
+| 7 | GPIO11 | 2 | `gpio_out_reg[7]` |
+| 8 | GPIO12 | 3 | `gpio_out_reg[8]` |
+| 9 | GPIO13 | 4 | `gpio_out_reg[9]` |
+| 10 | GPIO14 | 5 | `gpio_out_reg[10]` |
+| 11 | GPIO15 | 6 | `gpio_out_reg[11]` |
+| 12 | GPIO17 | 8 | `gpio_out_reg[12]` |
+| 13 | GPIO18 | 9 | `gpio_out_reg[13]` |
+
+**Important:** In the I/O Planner, ensure `i_gpio_pins[x]`, `o_gpio_pins[x]`, and `o_gpio_en[x]` are **all mapped to the same physical GPIO index** for each bit.
+
+---
+
+## How to Use
+
+### 1. FPGA Synthesis
+
+1. **Load Files:** Import `top.v` and `spi_target.v` into Renesas Go Configure Software Hub
+2. **I/O Planning:** In the I/O Planner, map each GPIO bit's `IN`, `OUT`, and `OE` signals to the same physical GPIO number (see table above)
+3. **Synthesize:** Run Synthesis, and then Generate Bitstream on the ForgeFPGA
+4. **Program:** Load the generated bitstream onto the Shrike Lite board
+
+### 2. MicroPython Firmware
+
+Upload the provided `fpga_gpio_14bit.py` to your RP2040/RP2350:
+
+```python
+from machine import Pin, SPI
+import time
+
+# Initialize
+fpga = ShrikeFPGA14GPIO()
+
+# Set pin directions (0=output, 1=input)
+fpga.set_all_directions(0x0000)  # All outputs
+
+# Write data
+fpga.write_all(0x1234)  # Write 0x1234 to all 14 pins
+
+# Read data
+value = fpga.read_all()  # Returns 14-bit value
+print(f"GPIO state: 0x{value:04X}")
+
+# Individual pin control
+fpga.set_pin_direction(0, is_input=False)  # Pin 0 as output
+fpga.write_pin(0, 1)  # Set pin 0 HIGH
+state = fpga.read_pin(0)  # Read pin 0
+```
+
+---

--- a/examples/14-Pin GPIO Extender/firmware/Micropython/14-Pin_GPIO_extender.py
+++ b/examples/14-Pin GPIO Extender/firmware/Micropython/14-Pin_GPIO_extender.py
@@ -1,0 +1,650 @@
+from machine import Pin, SPI
+import time
+
+class ShrikeFPGA14GPIO:
+    """
+    Driver for 14-bit FPGA GPIO control via SPI
+    
+    Pin Mapping (Register Bit -> FPGA Internal GPIO -> Physical Pin):
+    Bit 0  -> GPIO0  -> Pin 13
+    Bit 1  -> GPIO1  -> Pin 14
+    Bit 2  -> GPIO2  -> Pin 15
+    Bit 3  -> GPIO7  -> Pin 20
+    Bit 4  -> GPIO8  -> Pin 23
+    Bit 5  -> GPIO9  -> Pin 24
+    Bit 6  -> GPIO10 -> Pin 1
+    Bit 7  -> GPIO11 -> Pin 2
+    Bit 8  -> GPIO12 -> Pin 3
+    Bit 9  -> GPIO13 -> Pin 4
+    Bit 10 -> GPIO14 -> Pin 5
+    Bit 11 -> GPIO15 -> Pin 6
+    Bit 12 -> GPIO17 -> Pin 8
+    Bit 13 -> GPIO18 -> Pin 9
+    
+    Reserved/Used Pins:
+    - GPIO3  (Pin 16) -> SPI_SCK
+    - GPIO4  (Pin 17) -> SPI_SS
+    - GPIO5  (Pin 18) -> SPI_MOSI
+    - GPIO6  (Pin 19) -> SPI_MISO
+    - GPIO16 (Pin 7)  -> RST_N
+    
+    Command Protocol (2-byte):
+    CMD 0x10, DATA -> Set gpio_dir_reg[7:0]
+    CMD 0x11, DATA -> Set gpio_dir_reg[13:8] (uses bits [5:0])
+    CMD 0x20, DATA -> Set gpio_out_reg[7:0]
+    CMD 0x21, DATA -> Set gpio_out_reg[13:8] (uses bits [5:0])
+    
+    Direction: 1 = Input, 0 = Output
+    """
+    
+    # Complete pin mapping
+    PIN_MAP = {
+        0:  ("GPIO0",  13),
+        1:  ("GPIO1",  14),
+        2:  ("GPIO2",  15),
+        3:  ("GPIO7",  20),
+        4:  ("GPIO8",  23),
+        5:  ("GPIO9",  24),
+        6:  ("GPIO10", 1),
+        7:  ("GPIO11", 2),
+        8:  ("GPIO12", 3),
+        9:  ("GPIO13", 4),
+        10: ("GPIO14", 5),
+        11: ("GPIO15", 6),
+        12: ("GPIO17", 8),
+        13: ("GPIO18", 9),
+    }
+    
+    def __init__(self, spi_id=0, baudrate=500000, cs_pin=1):
+        """Initialize SPI interface to FPGA"""
+        self.spi = SPI(spi_id, 
+                       baudrate=baudrate,
+                       polarity=0, phase=0, bits=8,
+                       firstbit=SPI.MSB,
+                       sck=Pin(2), mosi=Pin(3), miso=Pin(0))
+        
+        self.cs = Pin(cs_pin, Pin.OUT)
+        self.cs.value(1)
+        
+        self.dir_reg = 0x3FFF  # All inputs (14 bits)
+        self.out_reg = 0x0000
+        
+    def _send_cmd(self, cmd, data):
+        """Send 2-byte command sequence"""
+        self.cs.value(0)
+        time.sleep_us(2)
+        self.spi.write(bytes([cmd, data]))
+        time.sleep_us(2)
+        self.cs.value(1)
+        time.sleep_us(20)
+    
+    def _read_gpio(self):
+        """Read all 14 GPIO pins (returns 14-bit value)"""
+        self.cs.value(0)
+        time.sleep_us(20)
+        # Read one byte at a time with delay
+        rx0 = self.spi.read(1, 0x00)[0]  # High byte
+        time.sleep_us(20)
+        rx1 = self.spi.read(1, 0x00)[0]  # Low byte
+        time.sleep_us(20)
+        self.cs.value(1)
+        time.sleep_us(50)
+        # CORRECTED: rx0 is HIGH byte, rx1 is LOW byte
+        result = rx1 | ((rx0 & 0x3F) << 8)
+        return result
+    
+    def set_pin_direction(self, pin, is_input):
+        """Set individual pin direction (0-13)"""
+        if pin < 0 or pin > 13:
+            raise ValueError("Pin must be 0-13")
+        
+        if is_input:
+            self.dir_reg |= (1 << pin)
+        else:
+            self.dir_reg &= ~(1 << pin)
+        
+        # Update FPGA
+        if pin < 8:
+            self._send_cmd(0x10, self.dir_reg & 0xFF)
+        else:
+            self._send_cmd(0x11, (self.dir_reg >> 8) & 0x3F)
+    
+    def set_all_directions(self, dir_14bit):
+        """Set all 14 pins direction (14-bit value)"""
+        self.dir_reg = dir_14bit & 0x3FFF
+        self._send_cmd(0x10, self.dir_reg & 0xFF)
+        self._send_cmd(0x11, (self.dir_reg >> 8) & 0x3F)
+    
+    def write_pin(self, pin, value):
+        """Write to individual output pin (0-13)"""
+        if pin < 0 or pin > 13:
+            raise ValueError("Pin must be 0-13")
+        
+        if value:
+            self.out_reg |= (1 << pin)
+        else:
+            self.out_reg &= ~(1 << pin)
+        
+        if pin < 8:
+            self._send_cmd(0x20, self.out_reg & 0xFF)
+        else:
+            self._send_cmd(0x21, (self.out_reg >> 8) & 0x3F)
+    
+    def write_all(self, value):
+        """Write to all 14 output pins"""
+        self.out_reg = value & 0x3FFF
+        self._send_cmd(0x20, self.out_reg & 0xFF)
+        self._send_cmd(0x21, (self.out_reg >> 8) & 0x3F)
+    
+    def read_all(self):
+        """Read all 14 GPIO pins"""
+        return self._read_gpio()
+    
+    def read_pin(self, pin):
+        """Read individual pin state (0-13)"""
+        if pin < 0 or pin > 13:
+            raise ValueError("Pin must be 0-13")
+        
+        gpio_state = self.read_all()
+        return (gpio_state >> pin) & 1
+    
+    def get_pin_info(self, pin):
+        """Get pin information"""
+        if pin in self.PIN_MAP:
+            gpio_name, phys_pin = self.PIN_MAP[pin]
+            return f"Bit{pin:2d} -> {gpio_name:6s} (Pin {phys_pin:2d})"
+        return f"Bit{pin:2d} -> Unknown"
+    
+    def print_pin_map(self):
+        """Print current pin states"""
+        print("\n" + "="*70)
+        print("FPGA 14-GPIO Pin Mapping & Status")
+        print("="*70)
+        current = self.read_all()
+        
+        for bit in range(14):
+            gpio_name, phys_pin = self.PIN_MAP[bit]
+            state = "HIGH" if (current >> bit) & 1 else "LOW"
+            direction = "IN " if (self.dir_reg >> bit) & 1 else "OUT"
+            print(f"Bit {bit:2d} | {gpio_name:6s} | Pin {phys_pin:2d} | {state:4s} ({direction})")
+        print("="*70)
+
+
+# ===== TEST FUNCTIONS =====
+
+def test_0_spi_diagnostic():
+    """
+    Test 0: SPI Communication Diagnostic
+    No external connections needed - verifies SPI is working
+    """
+    print("\n" + "="*70)
+    print("TEST 0: SPI COMMUNICATION DIAGNOSTIC")
+    print("="*70)
+    print("This test verifies basic SPI communication with FPGA\n")
+    
+    fpga = ShrikeFPGA14GPIO()
+    
+    # Test 1: Set all pins as inputs and read
+    print("Step 1: Setting all pins as inputs...")
+    fpga.set_all_directions(0x3FFF)
+    time.sleep_ms(50)
+    val = fpga.read_all()
+    print(f"  Read value: 0x{val:04X} (0b{val:014b})")
+    print(f"  Bits that are HIGH: {[i for i in range(14) if (val >> i) & 1]}")
+    
+    # Test 2: Set all pins as outputs, write all LOW
+    print("\nStep 2: Setting all pins as outputs, writing LOW...")
+    fpga.set_all_directions(0x0000)
+    time.sleep_ms(20)
+    fpga.write_all(0x0000)
+    time.sleep_ms(50)
+    val = fpga.read_all()
+    print(f"  Read value: 0x{val:04X} (0b{val:014b})")
+    print(f"  Expected: 0x0000 (all LOW)")
+    if val == 0x0000:
+        print("  ✓ PASS")
+    
+    # Test 3: Write all HIGH
+    print("\nStep 3: Writing all HIGH...")
+    fpga.write_all(0x3FFF)
+    time.sleep_ms(50)
+    val = fpga.read_all()
+    print(f"  Read value: 0x{val:04X} (0b{val:014b})")
+    print(f"  Expected: 0x3FFF (all HIGH)")
+    if val == 0x3FFF:
+        print("  ✓ PASS")
+    
+    # Test 4: Test each bit individually with debug
+    print("\nStep 4: Testing individual bits (outputs)...")
+    fpga.set_all_directions(0x0000)  # All outputs
+    time.sleep_ms(20)
+    
+    print("\nDetailed byte-level debug:")
+    for bit in [0, 1, 7, 8, 13]:
+        fpga.write_all(1 << bit)
+        time.sleep_ms(20)
+        
+        # Manual read with debug
+        fpga.cs.value(0)
+        time.sleep_us(10)
+        tx_dummy = bytes([0x00, 0x00])
+        rx = bytearray(2)
+        fpga.spi.write_readinto(tx_dummy, rx)
+        time.sleep_us(10)
+        fpga.cs.value(1)
+        time.sleep_us(50)
+        
+        val = rx[1] | ((rx[0] & 0x3F) << 8)  # CORRECTED byte order
+        expected = 1 << bit
+        match = "✓" if val == expected else "✗"
+        print(f"  Bit {bit:2d}: Wrote 0x{expected:04X}, Read 0x{val:04X} [Byte0=0x{rx[0]:02X}, Byte1=0x{rx[1]:02X}] {match}")
+    
+    fpga.write_all(0x0000)
+    print("\n✓ Diagnostic complete")
+    
+    # Additional raw byte test
+    print("\nStep 5: Raw byte sequence test...")
+    print("Testing what FPGA sends for known output patterns:")
+    test_vals = [0x0000, 0x00FF, 0x3F00, 0x3FFF, 0x1234]
+    for test_val in test_vals:
+        fpga.write_all(test_val)
+        time.sleep_ms(20)
+        
+        fpga.cs.value(0)
+        time.sleep_us(10)
+        rx = bytearray(2)
+        fpga.spi.write_readinto(bytes([0x00, 0x00]), rx)
+        time.sleep_us(10)
+        fpga.cs.value(1)
+        time.sleep_us(50)
+        
+        print(f"  Wrote: 0x{test_val:04X} -> Read bytes: [0x{rx[0]:02X}, 0x{rx[1]:02X}] = 0x{rx[1] | (rx[0] << 8):04X}")
+
+
+
+def test_1_loopback_pairs():
+    """
+    Test 1: Simple Loopback (7 pairs)
+    Connect these pairs with jumper wires:
+    Pin 13<->14, 15<->20, 23<->24, 1<->2, 3<->4, 5<->6, 8<->9
+    """
+    print("\n" + "="*70)
+    print("TEST 1: LOOPBACK PAIRS (7 pairs)")
+    print("="*70)
+    print("Connect jumper wires between FPGA physical pins:")
+    print("  Pin 13 <-> Pin 14  (Bit 0 <-> Bit 1)")
+    print("  Pin 15 <-> Pin 20  (Bit 2 <-> Bit 3)")
+    print("  Pin 23 <-> Pin 24  (Bit 4 <-> Bit 5)")
+    print("  Pin 1  <-> Pin 2   (Bit 6 <-> Bit 7)")
+    print("  Pin 3  <-> Pin 4   (Bit 8 <-> Bit 9)")
+    print("  Pin 5  <-> Pin 6   (Bit 10 <-> Bit 11)")
+    print("  Pin 8  <-> Pin 9   (Bit 12 <-> Bit 13)")
+    input("Press Enter when ready...")
+    
+    fpga = ShrikeFPGA14GPIO()
+    
+    # Set even bits as outputs, odd bits as inputs
+    # Pattern: 0b10101010101010 = 0x2AAA
+    fpga.set_all_directions(0x2AAA)
+    time.sleep_ms(20)
+    
+    print("\nTesting loopback patterns...")
+    test_patterns = [0x0000, 0x1555, 0x2AAA, 0x3FFF]
+    pass_count = 0
+    
+    for pattern in test_patterns:
+        fpga.write_all(pattern)
+        time.sleep_ms(20)
+        
+        readback = fpga.read_all()
+        
+        # Calculate expected: odd bits should mirror even bits
+        expected = 0
+        for i in range(7):  # 7 pairs
+            out_bit = (pattern >> (i*2)) & 1
+            expected |= (out_bit << (i*2))      # Even bit
+            expected |= (out_bit << (i*2 + 1))  # Odd bit
+        
+        passed = (readback == expected)
+        print(f"Write: 0x{pattern:04X}, Read: 0x{readback:04X}, Expect: 0x{expected:04X}", end="")
+        print(" ✓ PASS" if passed else " ✗ FAIL")
+        if passed:
+            pass_count += 1
+    
+    print(f"\nResult: {pass_count}/{len(test_patterns)} patterns passed")
+    fpga.print_pin_map()
+
+
+def test_2_individual_control():
+    """Test 2: Individual Pin Control - No external connections needed"""
+    print("\n" + "="*70)
+    print("TEST 2: INDIVIDUAL PIN CONTROL (14 pins)")
+    print("="*70)
+    print("No jumpers needed - tests register control\n")
+    
+    fpga = ShrikeFPGA14GPIO()
+    
+    for pin in range(14):
+        print(f"Testing {fpga.get_pin_info(pin)}")
+        
+        # Set as output
+        fpga.set_pin_direction(pin, is_input=False)
+        time.sleep_ms(5)
+        
+        # Toggle HIGH/LOW
+        fpga.write_pin(pin, 1)
+        time.sleep_ms(5)
+        print(f"  Set HIGH (out_reg = 0x{fpga.out_reg:04X})")
+        
+        fpga.write_pin(pin, 0)
+        time.sleep_ms(5)
+        print(f"  Set LOW  (out_reg = 0x{fpga.out_reg:04X})")
+        
+        # Set as input
+        fpga.set_pin_direction(pin, is_input=True)
+        time.sleep_ms(5)
+    
+    print("\n✓ All 14 pins tested successfully")
+    fpga.print_pin_map()
+
+
+def test_3_bidirectional():
+    """
+    Test 3: Bidirectional Test
+    Connect Pin 13 <-> Pin 9 (Bit 0 <-> Bit 13)
+    """
+    print("\n" + "="*70)
+    print("TEST 3: BIDIRECTIONAL SWITCHING")
+    print("="*70)
+    print("Connect jumper: Pin 13 <-> Pin 9 (Bit 0 <-> Bit 13)")
+    input("Press Enter when ready...")
+    
+    fpga = ShrikeFPGA14GPIO()
+    
+    print("\nTest A: Bit 0 (OUT) -> Bit 13 (IN)")
+    fpga.set_pin_direction(0, is_input=False)
+    fpga.set_pin_direction(13, is_input=True)
+    time.sleep_ms(10)
+    
+    pass_a = 0
+    for val in [0, 1, 0, 1]:
+        fpga.write_pin(0, val)
+        time.sleep_ms(10)
+        read_val = fpga.read_pin(13)
+        passed = (val == read_val)
+        print(f"  Bit 0 = {val}, Bit 13 = {read_val}", " ✓" if passed else " ✗")
+        if passed:
+            pass_a += 1
+    
+    print(f"Test A: {pass_a}/4 passed\n")
+    
+    print("Test B: Bit 13 (OUT) -> Bit 0 (IN)")
+    fpga.set_pin_direction(0, is_input=True)
+    fpga.set_pin_direction(13, is_input=False)
+    time.sleep_ms(10)
+    
+    pass_b = 0
+    for val in [1, 0, 1, 0]:
+        fpga.write_pin(13, val)
+        time.sleep_ms(10)
+        read_val = fpga.read_pin(0)
+        passed = (val == read_val)
+        print(f"  Bit 13 = {val}, Bit 0 = {read_val}", " ✓" if passed else " ✗")
+        if passed:
+            pass_b += 1
+    
+    print(f"Test B: {pass_b}/4 passed")
+    print(f"\nTotal: {pass_a + pass_b}/8 passed")
+
+
+def test_4_running_lights():
+    """
+    Test 4: Running Lights Pattern
+    Optional: Connect LEDs to verify visually
+    """
+    print("\n" + "="*70)
+    print("TEST 4: RUNNING LIGHTS (14-bit)")
+    print("="*70)
+    print("Optional: Connect LEDs with 330Ω resistors to any pins")
+    print("Or use multimeter/scope to verify")
+    input("Press Enter to start pattern...")
+    
+    fpga = ShrikeFPGA14GPIO()
+    
+    # Set all as outputs
+    fpga.set_all_directions(0x0000)
+    time.sleep_ms(10)
+    
+    print("\nRunning light pattern for 15 seconds...")
+    
+    start = time.ticks_ms()
+    while time.ticks_diff(time.ticks_ms(), start) < 15000:
+        # Forward sweep
+        for i in range(14):
+            fpga.write_all(1 << i)
+            time.sleep_ms(80)
+        
+        # Backward sweep
+        for i in range(12, 0, -1):
+            fpga.write_all(1 << i)
+            time.sleep_ms(80)
+    
+    fpga.write_all(0x0000)
+    print("✓ Pattern complete")
+    fpga.print_pin_map()
+
+
+def test_5_all_bits_toggle():
+    """
+    Test 5: All Bits Toggle Test
+    No external connections - tests full register writes
+    """
+    print("\n" + "="*70)
+    print("TEST 5: ALL BITS SIMULTANEOUS TOGGLE")
+    print("="*70)
+    print("No jumpers needed - tests 14-bit register control\n")
+    
+    fpga = ShrikeFPGA14GPIO()
+    
+    # Set all as outputs
+    fpga.set_all_directions(0x0000)
+    time.sleep_ms(10)
+    
+    patterns = [0x0000, 0x3FFF, 0x1555, 0x2AAA, 0x0F0F, 0x3030]
+    
+    print("Testing 14-bit patterns:")
+    for pattern in patterns:
+        fpga.write_all(pattern)
+        time.sleep_ms(100)
+        print(f"  Written: 0x{pattern:04X} (0b{pattern:014b})")
+    
+    fpga.write_all(0x0000)
+    print("\n✓ All 14-bit patterns written successfully")
+
+
+def test_6_chain_propagation():
+    """
+    Test 6: Signal Chain Propagation (Minimal - 4 wires)
+    Connect: Pin 13 -> 14 -> 15 -> 20
+    """
+    print("\n" + "="*70)
+    print("TEST 6: CHAIN PROPAGATION (4 pins)")
+    print("="*70)
+    print("Connect jumper chain:")
+    print("  Pin 13 -> 14 -> 15 -> 20")
+    print("  (Bit 0 -> Bit 1 -> Bit 2 -> Bit 3)")
+    input("Press Enter when ready...")
+    
+    fpga = ShrikeFPGA14GPIO()
+    
+    # Bit 0 output, rest inputs
+    fpga.set_all_directions(0x3FFE)  # All input except bit 0
+    time.sleep_ms(10)
+    
+    print("\nPropagating signal through chain...\n")
+    
+    for cycle in range(5):
+        # Drive HIGH
+        fpga.write_pin(0, 1)
+        time.sleep_ms(100)
+        state = fpga.read_all()
+        print(f"Cycle {cycle+1} HIGH: Bits[3:0] = 0b{(state & 0xF):04b}")
+        
+        # Drive LOW
+        fpga.write_pin(0, 0)
+        time.sleep_ms(100)
+        state = fpga.read_all()
+        print(f"Cycle {cycle+1} LOW:  Bits[3:0] = 0b{(state & 0xF):04b}")
+    
+    print("\n✓ Chain test complete")
+
+
+def run_all_tests():
+    """Run all tests sequentially"""
+    print("\n" + "="*70)
+    print("SHRIKE FPGA 14-GPIO TEST SUITE")
+    print("="*70)
+    
+    tests = [
+        test_0_spi_diagnostic,
+        test_1_loopback_pairs,
+        test_2_individual_control,
+        test_3_bidirectional,
+        test_4_running_lights,
+        test_5_all_bits_toggle,
+        test_6_chain_propagation
+    ]
+    
+    for i, test in enumerate(tests, 1):
+        try:
+            test()
+        except KeyboardInterrupt:
+            print("\n\nTest interrupted")
+            break
+        except Exception as e:
+            print(f"\n✗ Test {i} error: {e}")
+            import sys
+            sys.print_exception(e)
+        
+        if i < len(tests):
+            print("\n" + "-"*70)
+            input("Press Enter for next test...")
+    
+    print("\n" + "="*70)
+    print("ALL TESTS COMPLETE")
+    print("="*70)
+
+
+# ===== INTERACTIVE MODE =====
+
+def interactive_mode():
+    """Interactive REPL"""
+    print("\n" + "="*70)
+    print("INTERACTIVE MODE - 14 GPIO CONTROL")
+    print("="*70)
+    
+    fpga = ShrikeFPGA14GPIO()
+    fpga.print_pin_map()
+    
+    print("\nCommands:")
+    print("  map                 - Show pin mapping")
+    print("  dir <bit> <0|1>     - Set direction (0=out, 1=in)")
+    print("  write <bit> <0|1>   - Write bit value")
+    print("  read <bit>          - Read bit value")
+    print("  read_all            - Read all 14 bits")
+    print("  write_all <0xXXXX>  - Write all bits (14-bit hex)")
+    print("  exit                - Exit\n")
+    
+    while True:
+        try:
+            cmd = input("fpga> ").strip().split()
+            if not cmd:
+                continue
+            
+            if cmd[0] == "exit":
+                break
+            elif cmd[0] == "map":
+                fpga.print_pin_map()
+            elif cmd[0] == "dir" and len(cmd) == 3:
+                bit, val = int(cmd[1]), int(cmd[2])
+                fpga.set_pin_direction(bit, bool(val))
+                print(f"Set {fpga.get_pin_info(bit)} -> {'INPUT' if val else 'OUTPUT'}")
+            elif cmd[0] == "write" and len(cmd) == 3:
+                bit, val = int(cmd[1]), int(cmd[2])
+                fpga.write_pin(bit, val)
+                print(f"Wrote {fpga.get_pin_info(bit)} = {val}")
+            elif cmd[0] == "read" and len(cmd) == 2:
+                bit = int(cmd[1])
+                val = fpga.read_pin(bit)
+                print(f"{fpga.get_pin_info(bit)} = {val}")
+            elif cmd[0] == "read_all":
+                val = fpga.read_all()
+                print(f"All 14 bits = 0x{val:04X} (0b{val:014b})")
+                fpga.print_pin_map()
+            elif cmd[0] == "write_all" and len(cmd) == 2:
+                val = int(cmd[1], 0) & 0x3FFF
+                fpga.write_all(val)
+                print(f"Wrote all = 0x{val:04X}")
+            else:
+                print("Invalid command")
+        except Exception as e:
+            print(f"Error: {e}")
+
+
+# ===== MAIN MENU =====
+
+def main():
+    print("\n" + "="*70)
+    print("SHRIKE FPGA 14-GPIO TESTER")
+    print("="*70)
+    print("\n14 Available GPIO Pins:")
+    print("  Bits 0-2:   Pins 13, 14, 15")
+    print("  Bit 3:      Pin 20")
+    print("  Bits 4-5:   Pins 23, 24")
+    print("  Bits 6-11:  Pins 1, 2, 3, 4, 5, 6")
+    print("  Bits 12-13: Pins 8, 9")
+    
+    print("\n1. Run All Tests")
+    print("2. Test 0: SPI Diagnostic (no wires)")
+    print("3. Test 1: Loopback Pairs (7 wires)")
+    print("4. Test 2: Individual Control (no wires)")
+    print("5. Test 3: Bidirectional (1 wire)")
+    print("6. Test 4: Running Lights (optional LEDs)")
+    print("7. Test 5: All Bits Toggle (no wires)")
+    print("8. Test 6: Chain Propagation (4 wires)")
+    print("9. Interactive Mode")
+    print("10. Exit")
+    
+    while True:
+        try:
+            choice = input("\nSelect (1-10): ").strip()
+            
+            if choice == "1":
+                run_all_tests()
+            elif choice == "2":
+                test_0_spi_diagnostic()
+            elif choice == "3":
+                test_1_loopback_pairs()
+            elif choice == "4":
+                test_2_individual_control()
+            elif choice == "5":
+                test_3_bidirectional()
+            elif choice == "6":
+                test_4_running_lights()
+            elif choice == "7":
+                test_5_all_bits_toggle()
+            elif choice == "8":
+                test_6_chain_propagation()
+            elif choice == "9":
+                interactive_mode()
+            elif choice == "10":
+                print("Goodbye!")
+                break
+            else:
+                print("Invalid choice")
+        except KeyboardInterrupt:
+            print("\n\nExiting...")
+            break
+
+if __name__ == "__main__":
+    main()

--- a/examples/14-Pin GPIO Extender/firmware/Micropython/lite_tests.py
+++ b/examples/14-Pin GPIO Extender/firmware/Micropython/lite_tests.py
@@ -1,0 +1,386 @@
+"""
+Shrike FPGA 14-GPIO Simple Test Script
+========================================
+
+This is a beginner-friendly version that demonstrates how to control
+the FPGA's 14 GPIO pins step-by-step with clear explanations.
+
+Hardware Setup:
+- Shrike Lite board with FPGA programmed
+- No external connections needed for basic tests
+- Optional: Jumper wires for loopback tests
+
+"""
+
+from machine import Pin, SPI
+import time 
+
+
+# ==============================================================================
+# STEP 1: Initialize SPI Communication
+# ==============================================================================
+
+print("\n" + "="*60)
+print("SHRIKE FPGA GPIO - SIMPLE DEMO")
+print("="*60)
+
+# Create SPI object to talk to the FPGA
+# The RP2040 pins connect to FPGA as follows:
+#   GPIO 0 (MISO) <- Receives data from FPGA
+#   GPIO 1 (CS)   -> Chip Select (tells FPGA we're talking to it)
+#   GPIO 2 (SCK)  -> Clock signal
+#   GPIO 3 (MOSI) -> Sends data to FPGA
+
+spi = SPI(0,                    # Use SPI bus 0
+          baudrate=1000000,     # 1 MHz speed (1 million bits per second)
+          polarity=0,           # Clock is LOW when idle
+          phase=0,              # Sample data on first clock edge
+          bits=8,               # Send/receive 8 bits at a time
+          firstbit=SPI.MSB,     # Send most significant bit first
+          sck=Pin(2),           # Clock on GPIO 2
+          mosi=Pin(3),          # Data out on GPIO 3
+          miso=Pin(0))          # Data in on GPIO 0
+
+cs = Pin(1, Pin.OUT)            # Chip Select on GPIO 1
+cs.value(1)                     # CS is HIGH when not talking to FPGA
+
+print("✓ SPI initialized successfully")
+print("  - Speed: 1 MHz")
+print("  - MISO: GPIO 0, MOSI: GPIO 3, SCK: GPIO 2, CS: GPIO 1")
+
+
+# ==============================================================================
+# STEP 2: Define Helper Functions
+# ==============================================================================
+
+def send_command(cmd_byte, data_byte):
+    """
+    Send a 2-byte command to the FPGA.
+    
+    Args:
+        cmd_byte: Command code (0x10, 0x11, 0x20, 0x21)
+        data_byte: Data to send
+    
+    Example:
+        send_command(0x10, 0x00)  # Set pins 0-7 as outputs
+    """
+    cs.value(0)              # Pull CS LOW to start communication
+    time.sleep_us(10)        # Small delay for stability
+    spi.write(bytes([cmd_byte, data_byte]))  # Send 2 bytes
+    time.sleep_us(10)
+    cs.value(1)              # Pull CS HIGH to end communication
+    time.sleep_us(50)        # Wait for FPGA to process
+
+
+def read_gpio():
+    """
+    Read all 14 GPIO pins from the FPGA.
+    
+    Returns:
+        14-bit integer representing pin states (0 or 1 for each pin)
+    
+    The FPGA sends data in 2 bytes:
+        Byte 1: High byte [13:8] - upper 6 bits
+        Byte 2: Low byte [7:0]   - lower 8 bits
+    """
+    cs.value(0)              # Start communication
+    time.sleep_us(20)
+    
+    # Read first byte (high bits 13-8)
+    high_byte = spi.read(1, 0x00)[0]
+    time.sleep_us(20)
+    
+    # Read second byte (low bits 7-0)
+    low_byte = spi.read(1, 0x00)[0]
+    time.sleep_us(20)
+    
+    cs.value(1)              # End communication
+    time.sleep_us(50)
+    
+    # Combine the two bytes into one 14-bit number
+    # high_byte has bits [13:8], low_byte has bits [7:0]
+    gpio_value = low_byte | ((high_byte & 0x3F) << 8)
+    
+    return gpio_value
+
+
+def set_pin_direction(pin_num, is_input):
+    """
+    Set a single pin as input or output.
+    
+    Args:
+        pin_num: Pin number (0-13)
+        is_input: True for input, False for output
+    
+    Example:
+        set_pin_direction(0, False)  # Set pin 0 as output
+        set_pin_direction(5, True)   # Set pin 5 as input
+    """
+    if pin_num < 0 or pin_num > 13:
+        print(f"Error: Pin {pin_num} is out of range (0-13)")
+        return
+    
+    # The FPGA uses these commands:
+    # 0x10 = Set direction for pins 0-7
+    # 0x11 = Set direction for pins 8-13
+    
+    # We need to set the correct bit: 1=input, 0=output
+    if pin_num < 8:
+        # Pins 0-7: use command 0x10
+        # For simplicity, we'll set one pin at a time
+        # In real use, you'd read-modify-write to preserve other pins
+        bit_value = 1 if is_input else 0
+        mask = 1 << pin_num
+        if is_input:
+            send_command(0x10, 0xFF)  # Set all to input first (simple approach)
+        else:
+            send_command(0x10, 0x00)  # Set all to output first
+    else:
+        # Pins 8-13: use command 0x11
+        bit_value = 1 if is_input else 0
+        if is_input:
+            send_command(0x11, 0x3F)  # Set all to input
+        else:
+            send_command(0x11, 0x00)  # Set all to output
+    
+    direction = "INPUT" if is_input else "OUTPUT"
+    print(f"  Pin {pin_num} set as {direction}")
+
+
+def write_pin(pin_num, value):
+    """
+    Write HIGH (1) or LOW (0) to an output pin.
+    
+    Args:
+        pin_num: Pin number (0-13)
+        value: 1 for HIGH, 0 for LOW
+    
+    Example:
+        write_pin(0, 1)  # Set pin 0 HIGH
+        write_pin(3, 0)  # Set pin 3 LOW
+    """
+    if pin_num < 0 or pin_num > 13:
+        print(f"Error: Pin {pin_num} is out of range (0-13)")
+        return
+    
+    # The FPGA uses these commands:
+    # 0x20 = Write to pins 0-7
+    # 0x21 = Write to pins 8-13
+    
+    if pin_num < 8:
+        # Create a byte with just this pin set
+        data = (1 << pin_num) if value else 0
+        send_command(0x20, data)
+    else:
+        # Pins 8-13
+        data = (1 << (pin_num - 8)) if value else 0
+        send_command(0x21, data)
+    
+    state = "HIGH" if value else "LOW"
+    print(f"  Pin {pin_num} set to {state}")
+
+
+def write_all_pins(value):
+    """
+    Write to all 14 pins at once.
+    
+    Args:
+        value: 14-bit number (0x0000 to 0x3FFF)
+    
+    Example:
+        write_all_pins(0x3FFF)  # Set all pins HIGH
+        write_all_pins(0x0000)  # Set all pins LOW
+        write_all_pins(0x1234)  # Set pattern 0001001000110100
+    """
+    # Send lower 8 bits (pins 0-7)
+    send_command(0x20, value & 0xFF)
+    
+    # Send upper 6 bits (pins 8-13)
+    send_command(0x21, (value >> 8) & 0x3F)
+    
+    print(f"  All pins set to 0x{value:04X} (0b{value:014b})")
+
+
+def set_all_directions(value):
+    """
+    Set all 14 pin directions at once.
+    
+    Args:
+        value: 14-bit number where 1=input, 0=output
+    
+    Example:
+        set_all_directions(0x0000)  # All outputs
+        set_all_directions(0x3FFF)  # All inputs
+        set_all_directions(0x00AA)  # Pins 1,3,5,7 as inputs, rest outputs
+    """
+    # Send lower 8 bits (pins 0-7)
+    send_command(0x10, value & 0xFF)
+    
+    # Send upper 6 bits (pins 8-13)
+    send_command(0x11, (value >> 8) & 0x3F)
+    
+    print(f"  All directions set to 0x{value:04X}")
+
+
+# ==============================================================================
+# STEP 3: Simple Tests
+# ==============================================================================
+
+print("\n" + "-"*60)
+print("BASIC TESTS")
+print("-"*60)
+
+# TEST 1: Set all pins as outputs
+print("\nTest 1: Configure all pins as OUTPUTS")
+set_all_directions(0x0000)  # 0 = output
+time.sleep_ms(100)
+print("✓ All 14 pins are now outputs")
+
+# TEST 2: Turn all pins ON (HIGH)
+print("\nTest 2: Turn all pins HIGH")
+write_all_pins(0x3FFF)  # All bits = 1
+time.sleep_ms(100)
+
+# Read back to verify
+state = read_gpio()
+print(f"  Read back: 0x{state:04X}")
+if state == 0x3FFF:
+    print("✓ Success! All pins are HIGH")
+else:
+    print("⚠ Some pins may not be HIGH (this is OK if they're floating)")
+
+time.sleep(1)
+
+# TEST 3: Turn all pins OFF (LOW)
+print("\nTest 3: Turn all pins LOW")
+write_all_pins(0x0000)  # All bits = 0
+time.sleep_ms(100)
+
+state = read_gpio()
+print(f"  Read back: 0x{state:04X}")
+if state == 0x0000:
+    print("✓ Success! All pins are LOW")
+else:
+    print("⚠ Some pins reading HIGH (might be floating as inputs)")
+
+time.sleep(1)
+
+# TEST 4: Blink a single pin
+print("\nTest 4: Blink pin 0 (GPIO0, Physical Pin 13)")
+print("  If you have an LED on this pin, you'll see it blink!")
+
+for i in range(5):
+    write_pin(0, 1)  # Turn ON
+    print(f"  Blink {i+1}/5 - Pin 0 HIGH")
+    time.sleep_ms(300)
+    
+    write_pin(0, 0)  # Turn OFF
+    print(f"  Blink {i+1}/5 - Pin 0 LOW")
+    time.sleep_ms(300)
+
+print("✓ Blink test complete")
+
+# TEST 5: Running lights pattern
+print("\nTest 5: Running lights across all 14 pins")
+print("  Watch the pins light up in sequence!")
+
+for i in range(14):
+    pattern = 1 << i  # Create pattern with just one bit set
+    write_all_pins(pattern)
+    print(f"  Pin {i} active (pattern: 0x{pattern:04X})")
+    time.sleep_ms(150)
+
+write_all_pins(0x0000)  # Turn all off
+print("✓ Running lights complete")
+
+
+# ==============================================================================
+# STEP 4: Interactive Demo
+# ==============================================================================
+
+print("\n" + "="*60)
+print("INTERACTIVE DEMO")
+print("="*60)
+print("\nYou can now control the GPIO pins manually!")
+print("\nCommands:")
+print("  'on <pin>'   - Turn a pin HIGH (e.g., 'on 5')")
+print("  'off <pin>'  - Turn a pin LOW (e.g., 'off 5')")
+print("  'read'       - Read all pin states")
+print("  'blink <pin>'- Blink a pin 3 times")
+print("  'help'       - Show this help")
+print("  'exit'       - Exit the demo")
+
+# First, set all as outputs
+set_all_directions(0x0000)
+
+while True:
+    try:
+        cmd = input("\nfpga> ").strip().lower().split()
+        
+        if not cmd:
+            continue
+        
+        if cmd[0] == "exit":
+            print("Goodbye!")
+            break
+        
+        elif cmd[0] == "help":
+            print("\nCommands:")
+            print("  on <pin>    - Turn pin HIGH")
+            print("  off <pin>   - Turn pin LOW")
+            print("  read        - Read all pins")
+            print("  blink <pin> - Blink pin 3 times")
+            print("  exit        - Exit")
+        
+        elif cmd[0] == "on" and len(cmd) == 2:
+            pin = int(cmd[1])
+            if 0 <= pin <= 13:
+                write_pin(pin, 1)
+            else:
+                print("Error: Pin must be 0-13")
+        
+        elif cmd[0] == "off" and len(cmd) == 2:
+            pin = int(cmd[1])
+            if 0 <= pin <= 13:
+                write_pin(pin, 0)
+            else:
+                print("Error: Pin must be 0-13")
+        
+        elif cmd[0] == "read":
+            state = read_gpio()
+            print(f"\nGPIO State: 0x{state:04X} (binary: 0b{state:014b})")
+            print("\nPin states:")
+            for i in range(14):
+                bit = (state >> i) & 1
+                status = "HIGH" if bit else "LOW"
+                print(f"  Pin {i:2d}: {status}")
+        
+        elif cmd[0] == "blink" and len(cmd) == 2:
+            pin = int(cmd[1])
+            if 0 <= pin <= 13:
+                print(f"Blinking pin {pin}...")
+                for _ in range(3):
+                    write_pin(pin, 1)
+                    time.sleep_ms(200)
+                    write_pin(pin, 0)
+                    time.sleep_ms(200)
+                print("Done!")
+            else:
+                print("Error: Pin must be 0-13")
+        
+        else:
+            print("Unknown command. Type 'help' for commands.")
+    
+    except KeyboardInterrupt:
+        print("\n\nExiting...")
+        break
+    except Exception as e:
+        print(f"Error: {e}")
+
+# Clean up - turn all pins off
+print("\nCleaning up...")
+write_all_pins(0x0000)
+print("All pins set to LOW")
+print("\n" + "="*60)
+print("Demo complete!")
+print("="*60)

--- a/examples/14-Pin GPIO Extender/src/spi_target.v
+++ b/examples/14-Pin GPIO Extender/src/spi_target.v
@@ -1,0 +1,118 @@
+module spi_target #(
+  parameter CPOL   = 1'b0,  // When one, clock is low in idle, otherwise clock is high
+  parameter CPHA   = 1'b0,  // When one, sampling occurs at falling edge, otherwise at rising edge of non-inverted clock
+  parameter WIDTH  = 8,     // Determines the data width of SPI to the input and output data buses
+  parameter LSB    = 1'b0   // When one, data starts from LSB, otherwise data starts from MSB 
+) (
+// common ports 
+  input                  i_clk,           // input clock signal
+  input                  i_rst_n,         // input negative reset signal
+// control signal
+  input                  i_enable,        // input enable SPI target signal
+// SPI interface ports
+  input                  i_ss_n,          // input target select signal
+  input                  i_sck,           // input spi clock signal
+  input                  i_mosi,          // input controller output target input signal
+  output                 o_miso,          // output controller input target output signal
+  output                 o_miso_oe,       // output miso enable output signal
+//RX internal ports
+  output reg [WIDTH-1:0] o_rx_data,       // output data bus
+  output reg             o_rx_data_valid, // output receive data valid signal
+//TX internal ports
+  input      [WIDTH-1:0] i_tx_data,       // input data bus
+  output                 o_tx_data_hold   // output signal used to get tx data from i_tx_data input
+);
+
+// Signal declaration
+  reg               [2:0] r_ss_n_sync, r_sck_sync;
+  reg [$clog2(WIDTH-1):0] r_transmision_count;
+  reg         [WIDTH-1:0] r_miso_data;
+  wire                    w_sck_r_edge, w_sck_f_edge, w_sck_edge, w_sck_edge_op;
+
+// SPI input signals synchronization
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      r_ss_n_sync <= 'b111;
+    end else if (i_enable) begin
+      r_ss_n_sync <= {r_ss_n_sync[1:0], i_ss_n};
+    end else begin
+      r_ss_n_sync <= 'b111;
+    end
+  end
+
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      r_sck_sync <= 'h0;
+    end else if (i_enable) begin
+      r_sck_sync <= {r_sck_sync[1:0], i_sck};
+    end else begin
+      r_sck_sync <= 'h0;
+    end
+  end
+
+// Create rising and falling edge signals from spi_clk signal
+  assign w_sck_r_edge  = ~r_sck_sync[2] & r_sck_sync[1];
+  assign w_sck_f_edge  = r_sck_sync[2] & ~r_sck_sync[1];
+  assign w_sck_edge    = (CPHA^CPOL) ? w_sck_f_edge : w_sck_r_edge;
+  assign w_sck_edge_op = (CPHA^CPOL) ? w_sck_r_edge : w_sck_f_edge;
+
+// Create transmission bit counter
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      r_transmision_count <= 'h0;
+    end else if (!i_enable || r_ss_n_sync[1]) begin
+      r_transmision_count <= 'h0;
+    end else if (w_sck_edge) begin
+      if (r_transmision_count == WIDTH-1) begin
+        r_transmision_count <= 'h0;
+      end else begin
+        r_transmision_count <= r_transmision_count + 1;
+      end
+    end
+  end
+
+// Create o_rx_data bus and valid signals
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      o_rx_data <= 'h0;
+    end else if (w_sck_edge) begin
+      if (LSB) begin
+        o_rx_data <= {i_mosi, o_rx_data[WIDTH-1:1]};
+      end else begin
+        o_rx_data <= {o_rx_data[WIDTH-2:0], i_mosi};
+      end
+    end
+  end
+
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      o_rx_data_valid <= 1'b0;
+    end else if (r_ss_n_sync[1] || (r_transmision_count == 0 && w_sck_edge)) begin
+      o_rx_data_valid <= 1'b0;
+    end else if (w_sck_edge && r_transmision_count == WIDTH-1) begin
+      o_rx_data_valid <= 1'b1;
+    end
+  end
+
+// Create o_tx_data_hold signal
+  assign o_tx_data_hold = (~CPHA & r_ss_n_sync[2] & ~r_ss_n_sync[1]) | (r_transmision_count == 0 & w_sck_edge_op);
+
+// Create o_miso and OE signals
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      r_miso_data <= 'h0;
+    end else if (o_tx_data_hold) begin
+      r_miso_data <= i_tx_data;
+    end else if (w_sck_edge_op) begin
+      if (LSB) begin
+        r_miso_data <= r_miso_data >> 1;
+      end else begin
+        r_miso_data <= r_miso_data << 1;
+      end
+    end
+  end
+
+  assign o_miso    = (LSB) ? r_miso_data[0] : r_miso_data[WIDTH-1];
+  assign o_miso_oe = ~r_ss_n_sync[2];
+
+endmodule

--- a/examples/14-Pin GPIO Extender/src/top.v
+++ b/examples/14-Pin GPIO Extender/src/top.v
@@ -1,0 +1,120 @@
+(* top *) module top (
+    (* iopad_external_pin, clkbuf_inhibit *) input clk,
+    (* iopad_external_pin *) output clk_en,
+    (* iopad_external_pin *) input rst_n,
+
+    (* iopad_external_pin *) input spi_ss_n,   
+    (* iopad_external_pin *) input spi_sck,    
+    (* iopad_external_pin *) input spi_mosi,   
+    (* iopad_external_pin *) output spi_miso,  
+    (* iopad_external_pin *) output spi_miso_en,
+
+    // 14-bit GPIO Interface
+    (* iopad_external_pin *) input  [13:0] i_gpio_pins,
+    (* iopad_external_pin *) output [13:0] o_gpio_pins,
+    (* iopad_external_pin *) output [13:0] o_gpio_en
+);
+
+    assign clk_en = 1'b1;
+
+    // SPI module connections
+    wire [7:0] spi_rx_data;
+    wire spi_rx_valid;
+    wire [7:0] spi_tx_data;
+
+    // Instantiate SPI Target
+    spi_target #( .WIDTH(8) ) u_spi_target (
+        .i_clk(clk),
+        .i_rst_n(rst_n),
+        .i_enable(1'b1),
+        .i_ss_n(spi_ss_n),
+        .i_sck(spi_sck),
+        .i_mosi(spi_mosi),
+        .o_miso(spi_miso),
+        .o_miso_oe(spi_miso_en),
+        .o_rx_data(spi_rx_data),
+        .o_rx_data_valid(spi_rx_valid),
+        .i_tx_data(spi_tx_data),
+        .o_tx_data_hold()
+    );
+
+    // 14-bit GPIO Control Registers
+    reg [13:0] gpio_dir_reg; // 1=Input, 0=Output
+    reg [13:0] gpio_out_reg; // Output data
+    
+    // Byte selector for 14-bit reads
+    reg byte_select; // 0=high byte, 1=low byte
+    
+    // Command state machine
+    reg [7:0] cmd_byte;
+    reg state; // 0=waiting for command, 1=waiting for data
+    reg spi_rx_valid_d;
+
+    // Synchronize SS
+    reg [1:0] ss_sync;
+    wire ss_falling;
+    
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            ss_sync <= 2'b11;
+        end else begin
+            ss_sync <= {ss_sync[0], spi_ss_n};
+        end
+    end
+    
+    assign ss_falling = ss_sync[1] & ~ss_sync[0];
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            spi_rx_valid_d <= 1'b0;
+            gpio_dir_reg <= 14'h3FFF; // All inputs
+            gpio_out_reg <= 14'h0;
+            state <= 1'b0;
+            cmd_byte <= 8'h0;
+            byte_select <= 1'b0;
+        end else begin
+            spi_rx_valid_d <= spi_rx_valid;
+
+            // Reset byte selector on new transaction
+            if (ss_falling) begin
+                byte_select <= 1'b0;
+                state <= 1'b0;
+            end
+            // Toggle byte selector on each received byte
+            else if (spi_rx_valid && !spi_rx_valid_d) begin
+                byte_select <= ~byte_select;
+                
+                if (state == 1'b0) begin
+                    // Receive command byte
+                    cmd_byte <= spi_rx_data;
+                    state <= 1'b1;
+                end else begin
+                    // Execute command with data byte
+                    case (cmd_byte)
+                        8'h10: gpio_dir_reg[7:0] <= spi_rx_data;
+                        8'h11: gpio_dir_reg[13:8] <= spi_rx_data[5:0];
+                        8'h20: gpio_out_reg[7:0] <= spi_rx_data;
+                        8'h21: gpio_out_reg[13:8] <= spi_rx_data[5:0];
+                    endcase
+                    state <= 1'b0;
+                end
+            end
+            
+            // Reset on CS high
+            if (spi_ss_n) begin
+                state <= 1'b0;
+            end
+        end
+    end
+    
+    // Alternate between high and low bytes based on byte_select
+    assign spi_tx_data = byte_select ? 
+                         i_gpio_pins[7:0] :              // Low byte (second read)
+                         {2'b00, i_gpio_pins[13:8]};     // High byte (first read)
+
+    // GPIO Output Assignments
+    assign o_gpio_pins = gpio_out_reg;
+    assign o_gpio_en = ~gpio_dir_reg;
+
+endmodule
+// finally done

--- a/examples/8-Pin GPIO Extender/8_pin_gpio_extentdor.ffpga
+++ b/examples/8-Pin GPIO Extender/8_pin_gpio_extentdor.ffpga
@@ -1,0 +1,1003 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GPDProject version="40" oldestCompatibleVersion="32" GPDVersion="6.51.001" lastChange="16 Jan 2026 18:58:44" projectChecksumState="1" projectChecksum="539d8681">
+    <generalProjectSettings/>
+    <chip family="04" type="06" friendlyName="FFPGA" partNumber="67" package="26">
+        <nvmData registerLenght="480">0 0 0 28 0 0 0 0 A5 A5 A5 A5 0 0 0 0 0 0 0 0 5A 5A 5A 5A 0 0 0 0 22 22 22 22 22 22 22 22 22 22 0 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</nvmData>
+        <checksum crc32="0x451C1D42" version="2"/>
+        <VDDItem id="0">
+            <item id="0" caption="VDD (PIN 22)">
+                <graphics pos="(1350.00,143.10)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <VDDItem id="1">
+            <item id="1" caption="VDDIO (PIN 21)">
+                <graphics pos="(1350.00,226.67)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+            </item>
+        </VDDItem>
+        <item id="2" caption="GND (PIN 12)">
+            <graphics pos="(1350.00,298.48)" angle="0" flipping="2" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="3" caption="FPGA">
+            <graphics pos="(0.00,0.00)" angle="0" flipping="0" hidden="0" tOrigin="(640.00,442.50)"/>
+        </item>
+        <item id="4" caption="GPIO0 (PIN 13)">
+            <graphics pos="(35.00,592.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="5" caption="GPIO1 (PIN 14)">
+            <graphics pos="(150.00,542.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="6" caption="GPIO2 (PIN 15)">
+            <graphics pos="(35.00,493.59)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="7" caption="GPIO3 (PIN 16)">
+            <graphics pos="(150.00,444.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="8" caption="GPIO4 (PIN 17)">
+            <graphics pos="(35.00,394.74)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="9" caption="GPIO5 (PIN 18)">
+            <graphics pos="(35.00,197.00)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="10" caption="GPIO6 (PIN 19)">
+            <graphics pos="(150.00,148.09)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="11" caption="GPIO7 (PIN 20)">
+            <graphics pos="(35.00,98.66)" angle="0" flipping="0" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="12" caption="GPIO8 (PIN 23)">
+            <graphics pos="(1094.00,49.99)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="13" caption="GPIO9 (PIN 24)">
+            <graphics pos="(1200.00,102.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="14" caption="GPIO10 (PIN 1)">
+            <graphics pos="(1094.00,154.03)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="15" caption="GPIO11 (PIN 2)">
+            <graphics pos="(1200.00,206.11)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="16" caption="GPIO12 (PIN 3)">
+            <graphics pos="(1094.00,258.20)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="17" caption="GPIO13 (PIN 4)">
+            <graphics pos="(1200.00,310.28)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="18" caption="GPIO14 (PIN 5)">
+            <graphics pos="(1094.00,397.09)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="19" caption="GPIO15 (PIN 6)">
+            <graphics pos="(1200.00,449.75)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="20" caption="GPIO18 (PIN 9/GrP0)">
+            <graphics pos="(1094.00,604.84)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="21" caption="GPIO17 (PIN 8/GrP1)">
+            <graphics pos="(1200.00,553.34)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="22" caption="GPIO16 (PIN 7/GrP2)">
+            <graphics pos="(1094.00,501.25)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="23" caption="nRST (PIN 11)">
+            <graphics pos="(1094.00,356.17)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="24" caption="nSLEEP (PIN 10)">
+            <graphics pos="(1200.00,374.22)" angle="0" flipping="1" hidden="0" tOrigin="(20.00,10.00)"/>
+        </item>
+        <item id="25" caption="OSC">
+            <graphics pos="(150.00,64.53)" angle="0" flipping="0" hidden="0" tOrigin="(25.00,10.00)"/>
+        </item>
+        <item id="26" caption="Phase-Locked Loop">
+            <graphics pos="(149.73,246.87)" angle="180" flipping="0" hidden="0" tOrigin="(25.00,70.00)"/>
+        </item>
+        <item id="27" caption="BRAM">
+            <graphics pos="(616.77,701.83)" angle="90" flipping="0" hidden="0" tOrigin="(25.00,100.00)"/>
+        </item>
+        <item id="28" caption="FPGA Core">
+            <graphics pos="(340.90,49.43)" angle="0" flipping="0" hidden="0" tOrigin="(300.00,300.00)"/>
+        </item>
+        <wire output="79" input="65" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (236.00,80.00); (236.00,250.00); (220.00,250.00)</points>
+        </wire>
+        <wire output="2" input="66" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (226.00,510.00); (226.00,383.00); (220.00,383.00)</points>
+        </wire>
+        <wire output="83" input="85" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="0" wireText="NET0" wireState="0">
+            <points>(129.00,344.00); (116.00,344.00); (116.00,392.00); (308.00,392.00); (308.00,383.00); (320.00,383.00)</points>
+        </wire>
+        <wire output="84" input="86" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="1" wireText="NET1" wireState="0">
+            <points>(711.00,669.00); (711.00,756.00)</points>
+        </wire>
+        <wire output="85" input="87" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="2" wireText="NET2" wireState="0">
+            <points>(726.00,669.00); (726.00,756.00)</points>
+        </wire>
+        <wire output="86" input="88" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="3" wireText="NET3" wireState="0">
+            <points>(220.00,70.00); (320.00,70.00)</points>
+        </wire>
+        <wire output="79" input="38" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="4" wireText="NET4" wireState="0">
+            <points>(220.00,80.00); (314.00,80.00); (314.00,87.00); (320.00,87.00)</points>
+        </wire>
+        <wire output="39" input="63" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="5" wireText="NET5" wireState="0">
+            <points>(320.00,54.00); (116.00,54.00); (116.00,75.00); (129.00,75.00)</points>
+        </wire>
+        <wire output="20" input="62" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="6" wireText="NET6" wireState="0">
+            <points>(1177.00,384.00); (967.00,384.00); (967.00,385.00); (961.00,385.00)</points>
+        </wire>
+        <wire output="19" input="61" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="7" wireText="NET7" wireState="0">
+            <points>(1071.00,366.00); (967.00,366.00); (967.00,367.00); (961.00,367.00)</points>
+        </wire>
+        <wire output="82" input="41" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="8" wireText="NET8" wireState="0">
+            <points>(642.00,847.00); (642.00,853.00); (308.00,853.00); (308.00,645.00); (320.00,645.00)</points>
+        </wire>
+        <wire output="21" input="75" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="9" wireText="NET9" wireState="0">
+            <points>(557.00,669.00); (557.00,756.00)</points>
+        </wire>
+        <wire output="25" input="76" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="10" wireText="NET10" wireState="0">
+            <points>(618.00,669.00); (618.00,756.00)</points>
+        </wire>
+        <wire output="22" input="77" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="11" wireText="NET11" wireState="0">
+            <points>(573.00,669.00); (573.00,756.00)</points>
+        </wire>
+        <wire output="23" input="78" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="12" wireText="NET12" wireState="0">
+            <points>(588.00,669.00); (588.00,756.00)</points>
+        </wire>
+        <wire output="26" input="79" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="13" wireText="NET13" wireState="0">
+            <points>(634.00,669.00); (634.00,756.00)</points>
+        </wire>
+        <wire output="27" input="80" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="14" wireText="NET14" wireState="0">
+            <points>(649.00,669.00); (649.00,756.00)</points>
+        </wire>
+        <wire output="28" input="81" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="15" wireText="NET15" wireState="0">
+            <points>(664.00,669.00); (664.00,756.00)</points>
+        </wire>
+        <wire output="24" input="82" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="16" wireText="NET16" wireState="0">
+            <points>(603.00,669.00); (603.00,756.00)</points>
+        </wire>
+        <wire output="29" input="83" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="17" wireText="NET17" wireState="0">
+            <points>(680.00,669.00); (680.00,756.00)</points>
+        </wire>
+        <wire output="30" input="84" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="18" wireText="NET18" wireState="0">
+            <points>(695.00,669.00); (695.00,756.00)</points>
+        </wire>
+        <wire output="80" input="39" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="20" wireText="NET20" wireState="0">
+            <points>(129.00,289.00); (116.00,289.00); (116.00,240.00); (308.00,240.00); (308.00,251.00); (320.00,251.00)</points>
+        </wire>
+        <wire output="34" input="67" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="21" wireText="NET21" wireState="0">
+            <points>(320.00,333.00); (220.00,333.00)</points>
+        </wire>
+        <wire output="38" input="68" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="22" wireText="NET22" wireState="0">
+            <points>(320.00,267.00); (220.00,267.00)</points>
+        </wire>
+        <wire output="37" input="69" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="23" wireText="NET23" wireState="0">
+            <points>(320.00,284.00); (220.00,284.00)</points>
+        </wire>
+        <wire output="36" input="70" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="24" wireText="NET24" wireState="0">
+            <points>(320.00,300.00); (220.00,300.00)</points>
+        </wire>
+        <wire output="35" input="71" autoRouting="1" pen="#ff8000ff;3.00;1;32;128" lineType="4" protected="1" CWLid="25" wireText="NET25" wireState="0">
+            <points>(320.00,317.00); (220.00,317.00)</points>
+        </wire>
+        <wire output="33" input="72" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="26" wireText="NET26" wireState="0">
+            <points>(320.00,350.00); (220.00,350.00)</points>
+        </wire>
+        <wire output="32" input="73" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="27" wireText="NET27" wireState="0">
+            <points>(320.00,366.00); (220.00,366.00)</points>
+        </wire>
+        <wire output="41" input="0" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="28" wireText="NET28" wireState="0">
+            <points>(320.00,597.00); (97.00,597.00)</points>
+        </wire>
+        <wire output="42" input="1" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="29" wireText="NET29" wireState="0">
+            <points>(320.00,547.00); (212.00,547.00)</points>
+        </wire>
+        <wire output="43" input="2" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="30" wireText="NET30" wireState="0">
+            <points>(320.00,498.00); (97.00,498.00)</points>
+        </wire>
+        <wire output="44" input="3" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="31" wireText="NET31" wireState="0">
+            <points>(320.00,449.00); (212.00,449.00)</points>
+        </wire>
+        <wire output="45" input="4" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="32" wireText="NET32" wireState="0">
+            <points>(320.00,399.00); (97.00,399.00)</points>
+        </wire>
+        <wire output="46" input="5" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="33" wireText="NET33" wireState="0">
+            <points>(320.00,202.00); (97.00,202.00)</points>
+        </wire>
+        <wire output="47" input="6" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="34" wireText="NET34" wireState="0">
+            <points>(320.00,153.00); (212.00,153.00)</points>
+        </wire>
+        <wire output="48" input="7" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="35" wireText="NET35" wireState="0">
+            <points>(320.00,103.00); (97.00,103.00)</points>
+        </wire>
+        <wire output="49" input="8" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="36" wireText="NET36" wireState="0">
+            <points>(961.00,55.00); (1071.00,55.00)</points>
+        </wire>
+        <wire output="50" input="9" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="37" wireText="NET37" wireState="0">
+            <points>(961.00,107.00); (1177.00,107.00)</points>
+        </wire>
+        <wire output="51" input="10" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="38" wireText="NET38" wireState="0">
+            <points>(961.00,159.00); (1071.00,159.00)</points>
+        </wire>
+        <wire output="52" input="11" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="39" wireText="NET39" wireState="0">
+            <points>(961.00,211.00); (1177.00,211.00)</points>
+        </wire>
+        <wire output="53" input="12" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="40" wireText="NET40" wireState="0">
+            <points>(961.00,263.00); (1071.00,263.00)</points>
+        </wire>
+        <wire output="54" input="13" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="41" wireText="NET41" wireState="0">
+            <points>(961.00,315.00); (1177.00,315.00)</points>
+        </wire>
+        <wire output="55" input="14" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="42" wireText="NET42" wireState="0">
+            <points>(961.00,402.00); (1071.00,402.00)</points>
+        </wire>
+        <wire output="56" input="15" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="43" wireText="NET43" wireState="0">
+            <points>(961.00,454.00); (1177.00,454.00)</points>
+        </wire>
+        <wire output="57" input="16" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="44" wireText="NET44" wireState="0">
+            <points>(961.00,610.00); (1071.00,610.00)</points>
+        </wire>
+        <wire output="58" input="17" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="45" wireText="NET45" wireState="0">
+            <points>(961.00,558.00); (1177.00,558.00)</points>
+        </wire>
+        <wire output="59" input="18" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="46" wireText="NET46" wireState="0">
+            <points>(961.00,506.00); (1071.00,506.00)</points>
+        </wire>
+        <wire output="60" input="19" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="47" wireText="NET47" wireState="0">
+            <points>(320.00,630.00); (108.00,630.00); (108.00,648.00); (54.00,648.00); (54.00,633.00)</points>
+        </wire>
+        <wire output="61" input="20" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="48" wireText="NET48" wireState="0">
+            <points>(320.00,580.00); (220.00,580.00); (220.00,588.00); (169.00,588.00); (169.00,582.00)</points>
+        </wire>
+        <wire output="62" input="21" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="49" wireText="NET49" wireState="0">
+            <points>(320.00,531.00); (108.00,531.00); (108.00,552.00); (54.00,552.00); (54.00,534.00)</points>
+        </wire>
+        <wire output="63" input="22" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="50" wireText="NET50" wireState="0">
+            <points>(320.00,482.00); (220.00,482.00); (220.00,490.00); (169.00,490.00); (169.00,484.00)</points>
+        </wire>
+        <wire output="64" input="23" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="51" wireText="NET51" wireState="0">
+            <points>(320.00,432.00); (108.00,432.00); (108.00,448.00); (54.00,448.00); (54.00,435.00)</points>
+        </wire>
+        <wire output="65" input="24" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="52" wireText="NET52" wireState="0">
+            <points>(320.00,235.00); (108.00,235.00); (108.00,248.00); (54.00,248.00); (54.00,237.00)</points>
+        </wire>
+        <wire output="66" input="25" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="53" wireText="NET53" wireState="0">
+            <points>(320.00,185.00); (220.00,185.00); (220.00,194.00); (169.00,194.00); (169.00,188.00)</points>
+        </wire>
+        <wire output="67" input="26" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="54" wireText="NET54" wireState="0">
+            <points>(320.00,136.00); (108.00,136.00); (108.00,152.00); (54.00,152.00); (54.00,139.00)</points>
+        </wire>
+        <wire output="68" input="27" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="55" wireText="NET55" wireState="0">
+            <points>(961.00,90.00); (1060.00,90.00); (1060.00,96.00); (1113.00,96.00); (1113.00,90.00)</points>
+        </wire>
+        <wire output="69" input="28" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="56" wireText="NET56" wireState="0">
+            <points>(961.00,142.00); (1172.00,142.00); (1172.00,160.00); (1219.00,160.00); (1219.00,142.00)</points>
+        </wire>
+        <wire output="70" input="29" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="57" wireText="NET57" wireState="0">
+            <points>(961.00,194.00); (1060.00,194.00); (1060.00,200.00); (1113.00,200.00); (1113.00,194.00)</points>
+        </wire>
+        <wire output="71" input="30" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="58" wireText="NET58" wireState="0">
+            <points>(961.00,246.00); (1172.00,246.00); (1172.00,264.00); (1219.00,264.00); (1219.00,246.00)</points>
+        </wire>
+        <wire output="72" input="31" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="59" wireText="NET59" wireState="0">
+            <points>(961.00,298.00); (1060.00,298.00); (1060.00,304.00); (1113.00,304.00); (1113.00,298.00)</points>
+        </wire>
+        <wire output="73" input="32" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="60" wireText="NET60" wireState="0">
+            <points>(961.00,350.00); (1172.00,350.00); (1172.00,356.00); (1219.00,356.00); (1219.00,350.00)</points>
+        </wire>
+        <wire output="74" input="33" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="61" wireText="NET61" wireState="0">
+            <points>(961.00,437.00); (1060.00,437.00); (1060.00,443.00); (1113.00,443.00); (1113.00,437.00)</points>
+        </wire>
+        <wire output="75" input="34" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="62" wireText="NET62" wireState="0">
+            <points>(961.00,489.00); (1172.00,489.00); (1172.00,504.00); (1219.00,504.00); (1219.00,490.00)</points>
+        </wire>
+        <wire output="76" input="35" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="63" wireText="NET63" wireState="0">
+            <points>(961.00,645.00); (1060.00,645.00); (1060.00,664.00); (1113.00,664.00); (1113.00,645.00)</points>
+        </wire>
+        <wire output="77" input="36" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="64" wireText="NET64" wireState="0">
+            <points>(961.00,593.00); (1172.00,593.00); (1172.00,608.00); (1219.00,608.00); (1219.00,593.00)</points>
+        </wire>
+        <wire output="78" input="37" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="65" wireText="NET65" wireState="0">
+            <points>(961.00,541.00); (1060.00,541.00); (1060.00,547.00); (1113.00,547.00); (1113.00,541.00)</points>
+        </wire>
+        <wire output="0" input="42" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="66" wireText="NET66" wireState="0">
+            <points>(97.00,609.00); (314.00,609.00); (314.00,613.00); (320.00,613.00)</points>
+        </wire>
+        <wire output="1" input="43" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="67" wireText="NET67" wireState="0">
+            <points>(212.00,558.00); (314.00,558.00); (314.00,564.00); (320.00,564.00)</points>
+        </wire>
+        <wire output="2" input="44" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="19" wireText="NET19" wireState="0">
+            <points>(97.00,510.00); (314.00,510.00); (314.00,514.00); (320.00,514.00)</points>
+        </wire>
+        <wire output="3" input="45" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="68" wireText="NET68" wireState="0">
+            <points>(212.00,460.00); (314.00,460.00); (314.00,465.00); (320.00,465.00)</points>
+        </wire>
+        <wire output="4" input="46" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="69" wireText="NET69" wireState="0">
+            <points>(97.00,411.00); (314.00,411.00); (314.00,416.00); (320.00,416.00)</points>
+        </wire>
+        <wire output="5" input="47" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="70" wireText="NET70" wireState="0">
+            <points>(97.00,213.00); (314.00,213.00); (314.00,218.00); (320.00,218.00)</points>
+        </wire>
+        <wire output="6" input="48" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="71" wireText="NET71" wireState="0">
+            <points>(212.00,164.00); (314.00,164.00); (314.00,169.00); (320.00,169.00)</points>
+        </wire>
+        <wire output="7" input="49" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="72" wireText="NET72" wireState="0">
+            <points>(97.00,115.00); (314.00,115.00); (314.00,120.00); (320.00,120.00)</points>
+        </wire>
+        <wire output="8" input="50" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="73" wireText="NET73" wireState="0">
+            <points>(1071.00,66.00); (967.00,66.00); (967.00,72.00); (961.00,72.00)</points>
+        </wire>
+        <wire output="9" input="51" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="74" wireText="NET74" wireState="0">
+            <points>(1177.00,118.00); (967.00,118.00); (967.00,124.00); (961.00,124.00)</points>
+        </wire>
+        <wire output="10" input="52" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="75" wireText="NET75" wireState="0">
+            <points>(1071.00,170.00); (967.00,170.00); (967.00,176.00); (961.00,176.00)</points>
+        </wire>
+        <wire output="11" input="53" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="76" wireText="NET76" wireState="0">
+            <points>(1177.00,222.00); (967.00,222.00); (967.00,228.00); (961.00,228.00)</points>
+        </wire>
+        <wire output="12" input="54" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="77" wireText="NET77" wireState="0">
+            <points>(1071.00,275.00); (967.00,275.00); (967.00,280.00); (961.00,280.00)</points>
+        </wire>
+        <wire output="13" input="55" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="78" wireText="NET78" wireState="0">
+            <points>(1177.00,327.00); (967.00,327.00); (967.00,333.00); (961.00,333.00)</points>
+        </wire>
+        <wire output="14" input="56" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="79" wireText="NET79" wireState="0">
+            <points>(1071.00,413.00); (967.00,413.00); (967.00,419.00); (961.00,419.00)</points>
+        </wire>
+        <wire output="15" input="57" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="80" wireText="NET80" wireState="0">
+            <points>(1177.00,466.00); (967.00,466.00); (967.00,471.00); (961.00,471.00)</points>
+        </wire>
+        <wire output="16" input="58" autoRouting="1" pen="#0293fdff;1.00;1;32;128" lineType="7" protected="1" CWLid="81" wireText="NET81" wireState="0">
+            <points>(1071.00,621.00); (967.00,621.00); (967.00,628.00); (961.00,628.00)</points>
+        </wire>
+        <wire output="17" input="59" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="82" wireText="NET82" wireState="0">
+            <points>(1177.00,570.00); (967.00,570.00); (967.00,576.00); (961.00,576.00)</points>
+        </wire>
+        <wire output="18" input="60" autoRouting="1" pen="#ff8000ff;1.00;1;32;128" lineType="2" protected="1" CWLid="83" wireText="NET83" wireState="0">
+            <points>(1071.00,518.00); (967.00,518.00); (967.00,524.00); (961.00,524.00)</points>
+        </wire>
+    </chip>
+    <emulatorConfiguration version="4" oldestCompatibleVersion="4">
+        <settings>
+            <autoApply value="0"/>
+            <platformSelector id="-1"/>
+        </settings>
+        <platform id="0" friendlyName="GreenPAK DIP Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="1" friendlyName="GreenPAK Advanced Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="2" friendlyName="GreenPAK Pro Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="4" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="5" friendlyName="GreenPAK Advanced Development Platform w/ Logic Level Adapter #1">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="6" friendlyName="ForgeFPGA Deluxe Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="7" friendlyName="ForgeFPGA Evaluation Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="8" friendlyName="SLG51000 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="9" friendlyName="SLG51001 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="10" friendlyName="SLG51002 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="11" friendlyName="GreenPAK Serial Debugger">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="12" friendlyName="GreenPAK Lite Development Platform">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="13" friendlyName="HVPAK Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="14" friendlyName="SLG47105V Training Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="15" friendlyName="Power GreenPAK Development Motherboard">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="16" friendlyName="ForgeFPGA Deluxe Development Platform Rev. 2.0">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="17" friendlyName="HVPAK SLG47125 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="18" friendlyName="Go Configure Development Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="19" friendlyName="HVPAK SLG47125 Demo Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+        <platform id="20" friendlyName="Go Configure Development Board">
+            <lastConfiguration modified="0">
+                <SaveEmulator Name="Default">
+                    <PowerOptions synced="0"/>
+                    <ExternalChipConnectionSource source="0"/>
+                    <PowerSwitch internalPower="1" externalPower="0"/>
+                    <ExpansionConnector></ExpansionConnector>
+                    <TestPoints/>
+                    <I2C slaveAddress="-1"/>
+                </SaveEmulator>
+            </lastConfiguration>
+            <savedConfigurations/>
+        </platform>
+    </emulatorConfiguration>
+    <fpga-data>
+        <!--Fpga project data-->
+        <project-data-version>7</project-data-version>
+        <oldestCompatibleVersion>6</oldestCompatibleVersion>
+        <settings>
+            <generateBitstream>
+                <MAX_CPU>16</MAX_CPU>
+                <additionalArguments></additionalArguments>
+                <clockConcurrentOptimization>true</clockConcurrentOptimization>
+                <compilerVersion>23</compilerVersion>
+                <highDensityIOPacking>false</highDensityIOPacking>
+                <highDensityPackingLogic>true</highDensityPackingLogic>
+                <maximumRoutingIterations>300</maximumRoutingIterations>
+                <placeAndTrialRoute>false</placeAndTrialRoute>
+                <placeAndTrialRouteIterationCount>20</placeAndTrialRouteIterationCount>
+                <timingAnalysisCorner>0</timingAnalysisCorner>
+            </generateBitstream>
+            <simulation>
+                <wavedumpOutputFormat>1</wavedumpOutputFormat>
+            </simulation>
+            <synthesize>
+                <additionalArguments></additionalArguments>
+                <enableHardMultiplexerResources>true</enableHardMultiplexerResources>
+                <flatten>true</flatten>
+                <keep>false</keep>
+                <multiplexerResourcesNumber>5</multiplexerResourcesNumber>
+                <noDSP>true</noDSP>
+                <useABC9>true</useABC9>
+            </synthesize>
+        </settings>
+        <openedTabs>
+            <openedTab>main.v</openedTab>
+            <openedTab>spi_target.v</openedTab>
+            <openedTab>I/O Planner</openedTab>
+        </openedTabs>
+        <pipelineStagesStates>
+            <pipelineStageState>
+                <pipelineStage>0</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+            <pipelineStageState>
+                <pipelineStage>1</pipelineStage>
+                <pipelineState>1</pipelineState>
+            </pipelineStageState>
+        </pipelineStagesStates>
+        <modules>
+            <scr>
+                <module filename="main.v"/>
+                <module filename="spi_target.v"/>
+            </scr>
+            <lib/>
+            <sim/>
+            <netlists/>
+            <timing-constraints/>
+            <full-chip-simulation-models/>
+            <placement-constraints/>
+        </modules>
+        <io-spec-tool>
+            <records filter="16">
+                <record id="CLK_t[0:0]_W_in0">
+                    <port-name>clk</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:10]_in0">
+                    <port-name>spi_ss_n</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:22]_in0">
+                    <port-name>spi_mosi</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:23]_out0">
+                    <port-name>spi_miso</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:23]_out1">
+                    <port-name>spi_miso_en</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:24]_in0">
+                    <port-name>i_gpio_pins[0]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:24]_out0">
+                    <port-name>o_gpio_pins[0]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:24]_out1">
+                    <port-name>o_gpio_en[0]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:25]_out0">
+                    <port-name>clk_en</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[0:9]_in0">
+                    <port-name>spi_sck</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:22]_in0">
+                    <port-name>i_gpio_pins[6]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:22]_out0">
+                    <port-name>o_gpio_pins[6]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:22]_out1">
+                    <port-name>o_gpio_en[6]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:23]_in0">
+                    <port-name>i_gpio_pins[5]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:23]_out0">
+                    <port-name>o_gpio_pins[5]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:23]_out1">
+                    <port-name>o_gpio_en[5]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:24]_in0">
+                    <port-name>i_gpio_pins[4]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:24]_out0">
+                    <port-name>o_gpio_pins[4]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:24]_out1">
+                    <port-name>o_gpio_en[4]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:25]_in0">
+                    <port-name>i_gpio_pins[3]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:25]_out0">
+                    <port-name>o_gpio_pins[3]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:25]_out1">
+                    <port-name>o_gpio_en[3]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:26]_in0">
+                    <port-name>i_gpio_pins[2]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:26]_out0">
+                    <port-name>o_gpio_pins[2]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:26]_out1">
+                    <port-name>o_gpio_en[2]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:27]_in0">
+                    <port-name>i_gpio_pins[1]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:27]_out0">
+                    <port-name>o_gpio_pins[1]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:27]_out1">
+                    <port-name>o_gpio_en[1]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:4]_in0">
+                    <port-name>rst_n</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:9]_in0">
+                    <port-name>i_gpio_pins[7]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:9]_out0">
+                    <port-name>o_gpio_pins[7]</port-name>
+                </record>
+                <record id="IOB_t[0:0]_xy[31:9]_out1">
+                    <port-name>o_gpio_en[7]</port-name>
+                </record>
+            </records>
+        </io-spec-tool>
+        <macrocell-mode-data>
+            <scene-data>
+                <scene-width>32767</scene-width>
+                <scene-height>32767</scene-height>
+                <scene-snapToGrid>1</scene-snapToGrid>
+            </scene-data>
+            <macrocells-data>
+                <macrocell>
+                    <macrocell-id>18</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input18</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>-240</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>19</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>20</macrocell-id>
+                    <macrocell-type>2</macrocell-type>
+                    <macrocell-title>IN</macrocell-title>
+                    <macrocell-name>input20</macrocell-name>
+                    <macrocell-posx>-440</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports/>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>21</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>22</macrocell-id>
+                    <macrocell-type>4</macrocell-type>
+                    <macrocell-title>NOT Gate</macrocell-title>
+                    <macrocell-name>not22</macrocell-name>
+                    <macrocell-posx>-100</macrocell-posx>
+                    <macrocell-posy>0</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>23</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>24</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>25</macrocell-id>
+                    <macrocell-type>8</macrocell-type>
+                    <macrocell-title>NAND Gate</macrocell-title>
+                    <macrocell-name>nand25</macrocell-name>
+                    <macrocell-posx>240</macrocell-posx>
+                    <macrocell-posy>-200</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>26</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                        <port>
+                            <port-id>27</port-id>
+                            <port-index>1</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>2</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports>
+                        <port>
+                            <port-id>28</port-id>
+                            <port-index>0</port-index>
+                            <port-position>6</port-position>
+                            <port-is-multiconnect>1</port-is-multiconnect>
+                            <port-direction>2</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-output-ports>
+                </macrocell>
+                <macrocell>
+                    <macrocell-id>29</macrocell-id>
+                    <macrocell-type>3</macrocell-type>
+                    <macrocell-title>OUT</macrocell-title>
+                    <macrocell-name>output29</macrocell-name>
+                    <macrocell-posx>640</macrocell-posx>
+                    <macrocell-posy>-140</macrocell-posy>
+                    <macrocell-input-ports>
+                        <port>
+                            <port-id>30</port-id>
+                            <port-index>0</port-index>
+                            <port-position>5</port-position>
+                            <port-is-multiconnect>0</port-is-multiconnect>
+                            <port-direction>1</port-direction>
+                            <port-type>0</port-type>
+                            <port-adjacent-ports-num>1</port-adjacent-ports-num>
+                        </port>
+                    </macrocell-input-ports>
+                    <macrocell-output-ports/>
+                </macrocell>
+            </macrocells-data>
+            <wires-data>
+                <wire>
+                    <wire-id>31</wire-id>
+                    <wire-start-port-id>19</wire-start-port-id>
+                    <wire-end-port-id>26</wire-end-port-id>
+                    <wire-name>wire31</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>32</wire-id>
+                    <wire-start-port-id>21</wire-start-port-id>
+                    <wire-end-port-id>23</wire-end-port-id>
+                    <wire-name>wire32</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>33</wire-id>
+                    <wire-start-port-id>24</wire-start-port-id>
+                    <wire-end-port-id>27</wire-end-port-id>
+                    <wire-name>wire33</wire-name>
+                </wire>
+                <wire>
+                    <wire-id>34</wire-id>
+                    <wire-start-port-id>28</wire-start-port-id>
+                    <wire-end-port-id>30</wire-end-port-id>
+                    <wire-name>wire34</wire-name>
+                </wire>
+            </wires-data>
+        </macrocell-mode-data>
+        <pllConfigurator>
+            <!--PLL configurator data-->
+            <pllConfiguratorDataVersion>1</pllConfiguratorDataVersion>
+            <pllConfigurations>
+                <pllConfiguration>
+                    <pllFref>50.000000</pllFref>
+                    <pllIsManualCalculationMode>0</pllIsManualCalculationMode>
+                    <pllOutputChannels>
+                        <pllOutputChannel>
+                            <pllIsOutEnabled>1</pllIsOutEnabled>
+                            <pllRequiredFout>50.000000</pllRequiredFout>
+                            <pllRefDiv>1</pllRefDiv>
+                            <pllFbDiv>25</pllFbDiv>
+                            <pllPostDiv1>5</pllPostDiv1>
+                            <pllPostDiv2>5</pllPostDiv2>
+                        </pllOutputChannel>
+                    </pllOutputChannels>
+                    <pllProperties>
+                        <pllBypass>0</pllBypass>
+                        <pllClockSelection>0</pllClockSelection>
+                        <pllEnableUserClockByPll>0</pllEnableUserClockByPll>
+                        <pllLock>0</pllLock>
+                    </pllProperties>
+                </pllConfiguration>
+            </pllConfigurations>
+        </pllConfigurator>
+        <!--Fpga project data END-->
+    </fpga-data>
+    <projectData>
+        <specs>
+            <lastModify lastModifyValue="16.01.2026 10:43:13"/>
+            <vddSpecs vddMin="1.05" vddTyp="1.1" vddMax="1.15"/>
+            <vdd2Specs vdd2Min="1.71" vdd2Typ="2.5" vdd2Max="3.465"/>
+            <tempSpecs tempMin="-40" tempTyp="25" tempMax="85"/>
+        </specs>
+        <projectDataFields>
+            <textLineDataField name="Customer Name" id="2" text=""/>
+            <textLineDataField name="Customer Project Name" id="3" text=""/>
+            <textLineDataField name="Customer Project Number" id="4" text=""/>
+            <textLineDataField name="Customer Version Number" id="5" text=""/>
+            <multiTextLineDataField>
+                <textLineDataField name="Notes" id="6" text=""/>
+            </multiTextLineDataField>
+        </projectDataFields>
+    </projectData>
+    <i2cTool>
+        <i2cDebugger version="1"/>
+        <i2cStepper version="1" rowCount="0"/>
+        <i2cRegsTable version="1" tabCount="0"/>
+    </i2cTool>
+<logicAnalyzer>
+    <metadata>
+        <autosavePreset>-1</autosavePreset>
+        <currentPreset>-1</currentPreset>
+        <version>3</version>
+    </metadata>
+    <presetList/>
+</logicAnalyzer>
+
+</GPDProject>

--- a/examples/8-Pin GPIO Extender/README.md
+++ b/examples/8-Pin GPIO Extender/README.md
@@ -1,0 +1,94 @@
+# Shrike-GPIO: 8-Bit FPGA I/O Expander
+
+This project implements a custom **8-bit Bi-directional GPIO Expander** on the Vicharak **Shrike Lite** board. 
+
+By leveraging the FPGA's logic fabric, this design allows the RP2040 to control 8 additional independent pins via a high-speed **SPI interface**. The FPGA pins support dynamic direction switching (Input/Output) and manual read/write operations, effectively turning the FPGA into a versatile I/O expansion peripheral.
+
+---
+
+## System Architecture
+
+The system functions as a soft-command bridge between the microcontroller and the FPGA:
+* **RP2040 (Master):** Executes MicroPython/C++ firmware to send commands and read pin states.
+* **FPGA (Slave):** Contains a custom GPIO architecture that manages internal registers and physical tristate buffers.
+
+### Specifications
+| Feature | Detail |
+| :--- | :--- |
+| **I/O Width** | 8 Independent Bi-directional Pins |
+| **Interface** | 8-bit SPI (Address Nibble + Data Nibble) |
+| **Clocking** | Internal 50MHz Oscillator |
+| **Logic Type** | Memory-mapped Register Control |
+
+---
+
+## The SPI Interface
+
+To interact with the GPIOs, the RP2040 sends **8-bit packets** over SPI. Because the Renesas ForgeFPGA requires manual Output Enable (OE) management, the FPGA logic splits each physical pin into three internal signals: **Input**, **Output**, and **OE**.
+
+### Input Packet (RP2040 -> FPGA)
+The packet is structured as `{Address[3:0], Data[3:0]}`:
+
+| Address Nibble | Function | Description |
+| :---: | :--- | :--- |
+| `0x1` | **Lower DIR** | Set Directions for Pins [3:0] (1=Input, 0=Output) |
+| `0x2` | **Upper DIR** | Set Directions for Pins [7:4] (1=Input, 0=Output) |
+| `0x3` | **Lower DATA**| Drive logic levels (High/Low) for Pins [3:0] |
+| `0x4` | **Upper DATA**| Drive logic levels (High/Low) for Pins [7:4] |
+
+### Output Packet (FPGA -> RP2040)
+During every SPI transfer, the FPGA shifts out an 8-bit byte reflecting the **current physical logic state** of the 8 GPIO pins. This allows the RP2040 to "poll" the inputs while sending new output commands.
+
+
+
+---
+
+## Hardware Connections
+
+This design utilizes specific synthesis attributes to ensure the Renesas ForgeFPGA hardware maps the logic correctly to the physical pads.
+
+### Top Module Interface
+These signals correspond to the top-level Verilog module (`top.v`).
+
+| Signal | Direction | Description |
+| :--- | :--- | :--- |
+| `clk` | In | Internal 50 MHz Oscillator |
+| `clk_en` | Out | OSC Enable (tied to 1'b1) |
+| `rst_n` | In | System Reset (Active Low) |
+| `spi_ss_n` | In | SPI Slave Select |
+| `spi_sck` | In | SPI Clock |
+| `spi_mosi` | In | Master Out Slave In |
+| `spi_miso` | Out | Master In Slave Out |
+| `spi_miso_en`| Out | MISO Tristate Enable |
+
+### Pin Mapping Table
+
+| Signal Function | FPGA Pin (Label) | RP2040 Pin | Direction |
+| :--- | :---: | :---: | :--- |
+| **SPI Clock** | GPIO03 (Pin 2) | 2 | RP2040 -> FPGA |
+| **Chip Select** | GPIO04 (Pin 17) | 1 | RP2040 -> FPGA |
+| **MOSI** | GPIO05 (Pin 18) | 3 | RP2040 -> FPGA |
+| **MISO** | GPIO06 (Pin 19) | 0 | FPGA -> RP2040 |
+| **Reset** | GPIO18 (Pin 9) | 14 | RP2040 -> FPGA |
+
+### Target GPIO Mapping
+To maintain independent control, each bit is mapped to its own physical GPIO resource in the I/O Planner:
+
+| GPIO Bit | FPGA Label | Physical Pin |
+| :---: | :---: | :---: |
+| 0 | GPIO07 | 20 |
+| 1 | GPIO08 | 23 |
+| 2 | GPIO09 | 24 |
+| 3 | GPIO10 | 1 |
+| 4 | GPIO11 | 2 |
+| 5 | GPIO12 | 3 |
+| 6 | GPIO13 | 4 |
+| 7 | GPIO14 | 5 |
+
+---
+
+## How to Use
+
+1. **Synthesize:** Load `top.v` and `spi_target.v` into the Renesas Go Configure tool.
+2. **I/O Planning:** Ensure `i_gpio_pins[x]`, `o_gpio_pins[x]`, and `o_gpio_en[x]` are all mapped to the same physical GPIO index in the planner.
+3. **Firmware:** Use MicroPython on the RP2040 to send 8-bit SPI commands using the address/data nibble format described above.

--- a/examples/8-Pin GPIO Extender/example.md
+++ b/examples/8-Pin GPIO Extender/example.md
@@ -1,0 +1,46 @@
+# Controlling FPGA Pins with RP2040
+
+To help you understand how the **RP2040** controls the **FPGA** pins, let's walk through a concrete example: **Making an LED connected to FPGA Pin 20 (GPIO Bit 0) blink.**
+
+---
+
+## 1. The Setup
+
+* **Target Pin:** FPGA Pin 20 (Logic Label: `GPIO07`).
+* **Logic Index:** This corresponds to **Bit 0** of our 8-bit GPIO bus.
+* **Direction:** We need this pin to be an **Output** to drive the LED.
+* **State:** We want to toggle it between **High (3.3V)** and **Low (0V)**.
+
+---
+
+## Step 1: Setting the Direction (Input Packet 1)
+
+To make Bit 0 an output, we need to talk to the **Direction Register**. In our Verilog code, the opcode for the lower nibble (Bits 0-3) of the direction register is `0x1`.
+
+* **Direction Logic:** `0` = Output, `1` = Input.
+* **Command:** We want Bit 0 to be `0` (Output) and we'll leave the others as `1` (Input) for safety.
+* **Data Nibble:** `1110` in binary, which is `0xE` in hex.
+* **Full SPI Packet:** `0x1E` (Opcode 1 + Data E).
+
+> **What the FPGA does:** It receives `0x1E`, sees the `0x1` prefix, and writes `1110` into the lower 4 bits of `gpio_io_dir`. Because Bit 0 is now `0`, the FPGA hardware internally sets the **Output Enable (OE)** for Pin 20 to **High**.
+
+---
+
+## Step 2: Driving the Pin High (Input Packet 2)
+
+Now that the pin is an output, we need to send the data. The opcode for the lower nibble of the **Output Data Register** is `0x3`.
+
+* **Logic:** `1` = High (3.3V), `0` = Low (0V).
+* **Data Nibble:** We want Bit 0 to be `1`. Binary `0001`, which is `0x1` in hex.
+* **Full SPI Packet:** `0x31` (Opcode 3 + Data 1).
+
+> **What the FPGA does:** It receives `0x31`, sees the `0x3` prefix, and writes `0001` into the lower bits of `gpio_o_data_reg`. Since OE is already High from Step 1, Pin 20 immediately jumps to **3.3V**, and the LED turns on.
+
+---
+
+## Step 3: The Simultaneous Feedback (Output Packet)
+
+Every time you sent those commands above, the FPGA sent a byte back to the RP2040 at the **exact same time**.
+
+* **FPGA Action:** The FPGA looks at the physical voltage on all 8 pins and puts those values into a shift register.
+* **Result:** If Pin 20 successfully went High, the RP2040 will receive a byte where the last bit is `1` (e.g., `0b00000001`). This confirms to your Python script that the pin actually changed state.

--- a/examples/8-Pin GPIO Extender/firmware/Micropython/8-pin_extender.py
+++ b/examples/8-Pin GPIO Extender/firmware/Micropython/8-pin_extender.py
@@ -1,0 +1,88 @@
+from machine import Pin, SPI
+import time
+
+# --- Hardware Configuration ---
+# Based on your confirmed mapping
+sck_pin  = Pin(2)
+mosi_pin = Pin(3)
+miso_pin = Pin(0)
+ss_pin   = Pin(1, Pin.OUT, value=1)
+rst_pin  = Pin(14, Pin.OUT, value=1)
+
+# Probe pin to read physical FPGA output
+probe = Pin(15, Pin.IN) 
+
+# SPI0 Initialization (CPOL=0, CPHA=0)
+spi = SPI(0, baudrate=1_000_000, sck=sck_pin, mosi=mosi_pin, miso=miso_pin)
+
+# --- Register Addresses (From Verilog Case Statement) ---
+ADDR_DIR_LOW  = 0x1 # gpio_dir_reg[3:0]
+ADDR_DIR_HIGH = 0x2 # gpio_dir_reg[7:4]
+ADDR_OUT_LOW  = 0x3 # gpio_out_reg[3:0]
+ADDR_OUT_HIGH = 0x4 # gpio_out_reg[7:4]
+
+def send_cmd(addr, data):
+    """Sends command and returns the current physical state of the 8 GPIOs"""
+    packet = (addr << 4) | (data & 0x0F)
+    ss_pin.value(0)
+    # The MISO return value reflects i_gpio_pins
+    read_byte = spi.read(1, packet)[0]
+    ss_pin.value(1)
+    return read_byte
+
+def reset_fpga():
+    print("Action: Resetting FPGA Core...")
+    rst_pin.value(0)
+    time.sleep(0.1)
+    rst_pin.value(1) # De-assertion synchronized internally
+    time.sleep(0.1)
+
+# --- Test Suite ---
+def run_tests():
+    reset_fpga()
+    
+    # TEST 1: Default State Verification
+    # On reset, all pins should be Inputs (High-Z)
+    initial_state = send_cmd(0x0, 0x0)
+    print(f"Test 1: Reset State - Read: {bin(initial_state)} (Expected: All Inputs)")
+
+    # TEST 2: Lower Nibble Output Drive
+    print("\nTest 2: Lower Nibble (Pins 20, 23, 24, 1) Drive Test")
+    send_cmd(ADDR_DIR_LOW, 0x0) # Set lower 4 bits to Output (0)
+    print("Action: Connect Jumper from RP2040 GPIO 15 to FPGA Pin 20 (Bit 0)")
+    
+    for val in [0x1, 0x2, 0x4, 0x8]: # Walking 1s
+        send_cmd(ADDR_OUT_LOW, val)
+        time.sleep(0.1)
+        # Physical check on Bit 0 (only if val is 0x1)
+        if val == 0x1:
+            print(f" - Bit 0 High Check: {'PASS' if probe.value() == 1 else 'FAIL'}")
+        send_cmd(ADDR_OUT_LOW, 0x0) # Clear
+        time.sleep(0.1)
+
+    # TEST 3: Upper Nibble Independent Drive
+    print("\nTest 3: Upper Nibble (Pins 2, 3, 4, 5) Drive Test")
+    send_cmd(ADDR_DIR_HIGH, 0x0) # Set upper 4 bits to Output (0)
+    print("Action: Move Jumper to FPGA Pin 2 (Bit 4)")
+    
+    send_cmd(ADDR_OUT_HIGH, 0x1) # Set Bit 4 High
+    time.sleep(0.1)
+    print(f" - Bit 4 High Check: {'PASS' if probe.value() == 1 else 'FAIL'}")
+    
+    # TEST 4: Persistence Check
+    # Ensure writing upper nibble didn't overwrite lower nibble output state
+    send_cmd(ADDR_OUT_LOW, 0x1) # Bit 0 High
+    send_cmd(ADDR_OUT_HIGH, 0x8) # Bit 7 High
+    # Both should now be high in the readback
+    current_read = send_cmd(0x0, 0x0)
+    print(f"Test 4: Persistence Read - {bin(current_read)} (Should see bits 0 and 7 High)")
+
+    # TEST 5: Input Mode (Tristate) Verification
+    print("\nTest 5: Tristate/Input Mode Check")
+    send_cmd(ADDR_DIR_LOW, 0xF) # Set Lower to Input (1)
+    print("Action: Connect FPGA Pin 20 to 3.3V")
+    time.sleep(2) # Give user time to connect
+    input_read = send_cmd(0x0, 0x0)
+    print(f" - Pin 20 (Bit 0) High Input Detection: {'PASS' if (input_read & 0x01) else 'FAIL'}")
+
+run_tests()

--- a/examples/8-Pin GPIO Extender/firmware/Micropython/8-pin_extender_full_tests.py
+++ b/examples/8-Pin GPIO Extender/firmware/Micropython/8-pin_extender_full_tests.py
@@ -1,0 +1,560 @@
+from machine import Pin, SPI
+import time
+
+class ShrikeFPGAGPIO:
+    """
+    Driver for FPGA GPIO control via SPI
+    
+    Pin Mapping (FPGA Internal GPIO -> Physical Pin):
+    - GPIO03 (Pin 2)  -> SPI_SCLK
+    - GPIO04 (Pin 17) -> SPI_SS
+    - GPIO05 (Pin 18) -> SPI_SI (MOSI)
+    - GPIO06 (Pin 19) -> SPI_SO (MISO)
+    - GPIO18 (Pin 9)  -> RST_N
+    
+    Independent GPIO Pins (8-bit):
+    - Bit 0 -> GPIO07 (Pin 20)
+    - Bit 1 -> GPIO08 (Pin 23)
+    - Bit 2 -> GPIO09 (Pin 24)
+    - Bit 3 -> GPIO10 (Pin 1)
+    - Bit 4 -> GPIO11 (Pin 2)
+    - Bit 5 -> GPIO12 (Pin 3)
+    - Bit 6 -> GPIO13 (Pin 4)
+    - Bit 7 -> GPIO14 (Pin 5)
+    
+    Command Protocol: {Addr[3:0], Data[3:0]}
+    0x1X - Set GPIO[3:0] direction (lower nibble)
+    0x2X - Set GPIO[7:4] direction (upper nibble)
+    0x3X - Set GPIO[3:0] output data (lower nibble)
+    0x4X - Set GPIO[7:4] output data (upper nibble)
+    
+    Direction: 0 = Output, 1 = Input
+    """
+    
+    # Pin mapping reference
+    FPGA_PIN_MAP = {
+        0: "GPIO07 (FPGA Pin 20)",
+        1: "GPIO08 (FPGA Pin 23)",
+        2: "GPIO09 (FPGA Pin 24)",
+        3: "GPIO10 (FPGA Pin 1)",
+        4: "GPIO11 (FPGA Pin 2)",
+        5: "GPIO12 (FPGA Pin 3)",
+        6: "GPIO13 (FPGA Pin 4)",
+        7: "GPIO14 (FPGA Pin 5)"
+    }
+    
+    def __init__(self, spi_id=0, baudrate=1000000, cs_pin=1):
+        """
+        Initialize SPI interface to FPGA
+        
+        RP2040/RP2350 SPI Pins (based on your table):
+        - SCLK: GPIO 2  -> FPGA GPIO03 (Pin 2)
+        - MOSI: GPIO 3  -> FPGA GPIO05 (Pin 18)
+        - MISO: GPIO 0  -> FPGA GPIO06 (Pin 19)
+        - CS:   GPIO 1  -> FPGA GPIO04 (Pin 17)
+        """
+        self.spi = SPI(spi_id, 
+                       baudrate=baudrate,
+                       polarity=0,  # CPOL=0
+                       phase=0,     # CPHA=0
+                       bits=8,
+                       firstbit=SPI.MSB,
+                       sck=Pin(2),
+                       mosi=Pin(3),
+                       miso=Pin(0))
+        
+        self.cs = Pin(cs_pin, Pin.OUT)
+        self.cs.value(1)  # CS idle high
+        
+        # Internal state tracking
+        self.dir_reg = 0xFF  # All inputs initially
+        self.out_reg = 0x00  # All outputs low initially
+        
+    def _spi_transfer(self, data):
+        """Send command and read back GPIO state"""
+        self.cs.value(0)
+        time.sleep_us(1)
+        rx = self.spi.read(1, data)
+        time.sleep_us(1)
+        self.cs.value(1)
+        time.sleep_us(10)
+        return rx[0]
+    
+    def get_pin_name(self, pin):
+        """Get FPGA pin mapping for reference"""
+        return self.FPGA_PIN_MAP.get(pin, "Unknown")
+    
+    def set_pin_direction(self, pin, is_input):
+        """
+        Set individual pin direction
+        pin: 0-7 (maps to GPIO07-GPIO14)
+        is_input: True for input, False for output
+        """
+        if pin < 0 or pin > 7:
+            raise ValueError("Pin must be 0-7")
+        
+        if is_input:
+            self.dir_reg |= (1 << pin)
+        else:
+            self.dir_reg &= ~(1 << pin)
+        
+        # Update FPGA
+        if pin < 4:
+            cmd = 0x10 | (self.dir_reg & 0x0F)
+        else:
+            cmd = 0x20 | ((self.dir_reg >> 4) & 0x0F)
+        
+        self._spi_transfer(cmd)
+    
+    def set_all_directions(self, dir_byte):
+        """
+        Set all 8 pins direction at once
+        dir_byte: 8-bit value (1=Input, 0=Output)
+        """
+        self.dir_reg = dir_byte & 0xFF
+        self._spi_transfer(0x10 | (self.dir_reg & 0x0F))
+        self._spi_transfer(0x20 | ((self.dir_reg >> 4) & 0x0F))
+    
+    def write_pin(self, pin, value):
+        """
+        Write to individual output pin
+        pin: 0-7 (maps to GPIO07-GPIO14)
+        value: 0 or 1
+        """
+        if pin < 0 or pin > 7:
+            raise ValueError("Pin must be 0-7")
+        
+        if value:
+            self.out_reg |= (1 << pin)
+        else:
+            self.out_reg &= ~(1 << pin)
+        
+        # Update FPGA
+        if pin < 4:
+            cmd = 0x30 | (self.out_reg & 0x0F)
+        else:
+            cmd = 0x40 | ((self.out_reg >> 4) & 0x0F)
+        
+        self._spi_transfer(cmd)
+    
+    def write_all(self, value):
+        """Write to all 8 output pins at once"""
+        self.out_reg = value & 0xFF
+        self._spi_transfer(0x30 | (self.out_reg & 0x0F))
+        self._spi_transfer(0x40 | ((self.out_reg >> 4) & 0x0F))
+    
+    def read_all(self):
+        """Read all 8 GPIO pins state"""
+        # Send dummy command to get readback
+        gpio_state = self._spi_transfer(0x00)
+        return gpio_state
+    
+    def read_pin(self, pin):
+        """Read individual pin state"""
+        if pin < 0 or pin > 7:
+            raise ValueError("Pin must be 0-7")
+        
+        gpio_state = self.read_all()
+        return (gpio_state >> pin) & 1
+    
+    def print_pin_map(self):
+        """Print the pin mapping for reference"""
+        print("\nFPGA GPIO Pin Mapping:")
+        print("="*60)
+        print("Bit | Internal GPIO | Physical Pin | Current State")
+        print("-"*60)
+        current_state = self.read_all()
+        for bit in range(8):
+            state = "HIGH" if (current_state >> bit) & 1 else "LOW"
+            direction = "IN" if (self.dir_reg >> bit) & 1 else "OUT"
+            if bit == 0:
+                print(f" {bit}  | GPIO07        | Pin 20       | {state} ({direction})")
+            elif bit == 1:
+                print(f" {bit}  | GPIO08        | Pin 23       | {state} ({direction})")
+            elif bit == 2:
+                print(f" {bit}  | GPIO09        | Pin 24       | {state} ({direction})")
+            elif bit == 3:
+                print(f" {bit}  | GPIO10        | Pin 1        | {state} ({direction})")
+            elif bit == 4:
+                print(f" {bit}  | GPIO11        | Pin 2        | {state} ({direction})")
+            elif bit == 5:
+                print(f" {bit}  | GPIO12        | Pin 3        | {state} ({direction})")
+            elif bit == 6:
+                print(f" {bit}  | GPIO13        | Pin 4        | {state} ({direction})")
+            elif bit == 7:
+                print(f" {bit}  | GPIO14        | Pin 5        | {state} ({direction})")
+        print("="*60)
+
+
+# ===== TEST FUNCTIONS =====
+
+def test_1_loopback():
+    """
+    Test 1: Loopback Test
+    Connect FPGA pins in pairs with jumper wires:
+    - Bit 0 (GPIO07/Pin 20) to Bit 1 (GPIO08/Pin 23)
+    - Bit 2 (GPIO09/Pin 24) to Bit 3 (GPIO10/Pin 1)
+    - Bit 4 (GPIO11/Pin 2)  to Bit 5 (GPIO12/Pin 3)
+    - Bit 6 (GPIO13/Pin 4)  to Bit 7 (GPIO14/Pin 5)
+    """
+    print("\n" + "="*60)
+    print("TEST 1: LOOPBACK TEST")
+    print("="*60)
+    print("Connect jumper wires between FPGA physical pins:")
+    print("  Pin 20 (GPIO07/Bit 0) <-> Pin 23 (GPIO08/Bit 1)")
+    print("  Pin 24 (GPIO09/Bit 2) <-> Pin 1  (GPIO10/Bit 3)")
+    print("  Pin 2  (GPIO11/Bit 4) <-> Pin 3  (GPIO12/Bit 5)")
+    print("  Pin 4  (GPIO13/Bit 6) <-> Pin 5  (GPIO14/Bit 7)")
+    input("Press Enter when ready...")
+    
+    fpga = ShrikeFPGAGPIO()
+    
+    # Set even bits as outputs, odd bits as inputs
+    # Dir: 0=Output, 1=Input -> 0b10101010 = 0xAA
+    fpga.set_all_directions(0xAA)
+    time.sleep_ms(10)
+    
+    print("\nTesting loopback patterns...")
+    test_patterns = [0x00, 0x55, 0xAA, 0xFF]
+    pass_count = 0
+    
+    for pattern in test_patterns:
+        # Write pattern to output pins (even bits)
+        fpga.write_all(pattern)
+        time.sleep_ms(10)
+        
+        # Read back
+        readback = fpga.read_all()
+        
+        # Expected: odd bits should match even bits
+        expected = 0
+        for i in range(4):
+            out_bit = (pattern >> (i*2)) & 1
+            expected |= (out_bit << (i*2))      # Even bit
+            expected |= (out_bit << (i*2 + 1))  # Odd bit (looped back)
+        
+        passed = (readback == expected)
+        print(f"Written: 0x{pattern:02X}, Read: 0x{readback:02X}, Expected: 0x{expected:02X}", end="")
+        print(" ✓ PASS" if passed else " ✗ FAIL")
+        if passed:
+            pass_count += 1
+    
+    print(f"\nResult: {pass_count}/{len(test_patterns)} patterns passed")
+    fpga.print_pin_map()
+
+
+def test_2_individual_pins():
+    """
+    Test 2: Individual Pin Control
+    No jumpers needed - tests direction and output control
+    """
+    print("\n" + "="*60)
+    print("TEST 2: INDIVIDUAL PIN CONTROL")
+    print("="*60)
+    print("This test verifies individual pin direction/output control")
+    print("No jumpers needed - uses internal state verification\n")
+    
+    fpga = ShrikeFPGAGPIO()
+    
+    # Test each pin individually
+    for pin in range(8):
+        pin_name = fpga.get_pin_name(pin)
+        print(f"\nTesting Bit {pin} -> {pin_name}")
+        
+        # Set as output
+        fpga.set_pin_direction(pin, is_input=False)
+        time.sleep_ms(5)
+        
+        # Write HIGH
+        fpga.write_pin(pin, 1)
+        time.sleep_ms(5)
+        print(f"  Set HIGH (out_reg = 0x{fpga.out_reg:02X})")
+        
+        # Write LOW
+        fpga.write_pin(pin, 0)
+        time.sleep_ms(5)
+        print(f"  Set LOW  (out_reg = 0x{fpga.out_reg:02X})")
+        
+        # Set as input
+        fpga.set_pin_direction(pin, is_input=True)
+        time.sleep_ms(5)
+        print(f"  Set INPUT (dir_reg = 0x{fpga.dir_reg:02X})")
+    
+    print("\n✓ Individual pin control test complete")
+    fpga.print_pin_map()
+
+
+def test_3_walking_ones():
+    """
+    Test 3: Walking 1's Pattern
+    Connect GPIO pins in a chain:
+    Pin 20 -> 23 -> 24 -> 1 -> 2 -> 3 -> 4 -> 5
+    """
+    print("\n" + "="*60)
+    print("TEST 3: WALKING 1's PATTERN")
+    print("="*60)
+    print("Connect jumper wires in chain (FPGA physical pins):")
+    print("  Pin 20 -> 23 -> 24 -> 1 -> 2 -> 3 -> 4 -> 5")
+    print("  (GPIO07 -> GPIO08 -> GPIO09 -> GPIO10 -> GPIO11 -> GPIO12 -> GPIO13 -> GPIO14)")
+    input("Press Enter when ready...")
+    
+    fpga = ShrikeFPGAGPIO()
+    
+    # Bit 0 (GPIO07/Pin 20) as output, rest as inputs
+    fpga.set_all_directions(0xFE)  # 11111110
+    time.sleep_ms(10)
+    
+    print("\nWalking HIGH through the chain...")
+    print("(Bit 0/GPIO07/Pin 20 is driven, others should follow)\n")
+    
+    for i in range(5):  # Run 5 cycles
+        # Drive bit 0 HIGH
+        fpga.write_pin(0, 1)
+        time.sleep_ms(100)
+        
+        # Read and display
+        state = fpga.read_all()
+        print(f"Cycle {i+1}: Read = 0b{state:08b} (0x{state:02X})")
+        
+        # Drive bit 0 LOW
+        fpga.write_pin(0, 0)
+        time.sleep_ms(100)
+    
+    print("\n✓ If you see 1's propagating, the chain is connected correctly")
+
+
+def test_4_bidirectional():
+    """
+    Test 4: Bidirectional Communication
+    Connect Bit 0 (GPIO07/Pin 20) <-> Bit 4 (GPIO11/Pin 2)
+    """
+    print("\n" + "="*60)
+    print("TEST 4: BIDIRECTIONAL TEST")
+    print("="*60)
+    print("Connect jumper wire between FPGA physical pins:")
+    print("  Pin 20 (GPIO07/Bit 0) <-> Pin 2 (GPIO11/Bit 4)")
+    input("Press Enter when ready...")
+    
+    fpga = ShrikeFPGAGPIO()
+    
+    print("\nTest A: Bit 0 (OUT) -> Bit 4 (IN)")
+    fpga.set_pin_direction(0, is_input=False)
+    fpga.set_pin_direction(4, is_input=True)
+    time.sleep_ms(10)
+    
+    pass_count = 0
+    for val in [0, 1, 0, 1]:
+        fpga.write_pin(0, val)
+        time.sleep_ms(10)
+        read_val = fpga.read_pin(4)
+        passed = (val == read_val)
+        print(f"  Bit 0 (GPIO07) = {val}, Bit 4 (GPIO11) = {read_val}", end="")
+        print(" ✓" if passed else " ✗")
+        if passed:
+            pass_count += 1
+    
+    print(f"Test A: {pass_count}/4 passed\n")
+    
+    print("Test B: Bit 4 (OUT) -> Bit 0 (IN)")
+    fpga.set_pin_direction(0, is_input=True)
+    fpga.set_pin_direction(4, is_input=False)
+    time.sleep_ms(10)
+    
+    pass_count = 0
+    for val in [1, 0, 1, 0]:
+        fpga.write_pin(4, val)
+        time.sleep_ms(10)
+        read_val = fpga.read_pin(0)
+        passed = (val == read_val)
+        print(f"  Bit 4 (GPIO11) = {val}, Bit 0 (GPIO07) = {read_val}", end="")
+        print(" ✓" if passed else " ✗")
+        if passed:
+            pass_count += 1
+    
+    print(f"Test B: {pass_count}/4 passed")
+
+
+def test_5_blink_pattern():
+    """
+    Test 5: LED Blink Pattern (if you have LEDs with resistors)
+    If no LEDs, you can measure with multimeter or scope
+    """
+    print("\n" + "="*60)
+    print("TEST 5: BLINK PATTERN")
+    print("="*60)
+    print("Optional: Connect LEDs with 330Ω resistors to FPGA pins:")
+    print("  Pin 20, 23, 24, 1, 2, 3, 4, 5")
+    print("  (GPIO07-GPIO14)")
+    print("Or use multimeter/oscilloscope to verify outputs")
+    input("Press Enter to start blinking...")
+    
+    fpga = ShrikeFPGAGPIO()
+    
+    # Set all as outputs
+    fpga.set_all_directions(0x00)
+    time.sleep_ms(10)
+    
+    print("\nRunning blink patterns for 10 seconds...")
+    print("Pattern: Running lights (Bit 0->7->0)\n")
+    
+    start_time = time.ticks_ms()
+    while time.ticks_diff(time.ticks_ms(), start_time) < 10000:
+        # Forward
+        for i in range(8):
+            fpga.write_all(1 << i)
+            time.sleep_ms(100)
+        
+        # Backward
+        for i in range(6, 0, -1):
+            fpga.write_all(1 << i)
+            time.sleep_ms(100)
+    
+    fpga.write_all(0x00)
+    print("✓ Pattern complete")
+    fpga.print_pin_map()
+
+
+def run_all_tests():
+    """Run all tests in sequence"""
+    print("\n" + "="*60)
+    print("SHRIKE FPGA GPIO TEST SUITE")
+    print("="*60)
+    
+    tests = [
+        test_1_loopback,
+        test_2_individual_pins,
+        test_3_walking_ones,
+        test_4_bidirectional,
+        test_5_blink_pattern
+    ]
+    
+    for i, test in enumerate(tests, 1):
+        try:
+            test()
+        except KeyboardInterrupt:
+            print("\n\nTest interrupted by user")
+            break
+        except Exception as e:
+            print(f"\n✗ Test {i} failed with error: {e}")
+            import sys
+            sys.print_exception(e)
+        
+        if i < len(tests):
+            print("\n" + "-"*60)
+            input("Press Enter for next test...")
+    
+    print("\n" + "="*60)
+    print("ALL TESTS COMPLETE")
+    print("="*60)
+
+
+# ===== INTERACTIVE MODE =====
+
+def interactive_mode():
+    """Interactive REPL for manual testing"""
+    print("\n" + "="*60)
+    print("INTERACTIVE MODE")
+    print("="*60)
+    
+    fpga = ShrikeFPGAGPIO()
+    fpga.print_pin_map()
+    
+    print("\nAvailable commands:")
+    print("  map                 - Show pin mapping")
+    print("  dir <bit> <0|1>     - Set bit direction (0=out, 1=in)")
+    print("  write <bit> <0|1>   - Write bit value")
+    print("  read <bit>          - Read bit value")
+    print("  read_all            - Read all bits")
+    print("  write_all <0xXX>    - Write all bits")
+    print("  exit                - Exit interactive mode")
+    print()
+    
+    while True:
+        try:
+            cmd = input("fpga> ").strip().split()
+            if not cmd:
+                continue
+            
+            if cmd[0] == "exit":
+                break
+            elif cmd[0] == "map":
+                fpga.print_pin_map()
+            elif cmd[0] == "dir" and len(cmd) == 3:
+                pin, val = int(cmd[1]), int(cmd[2])
+                fpga.set_pin_direction(pin, bool(val))
+                print(f"Set Bit {pin} ({fpga.get_pin_name(pin)}) direction = {'INPUT' if val else 'OUTPUT'}")
+            elif cmd[0] == "write" and len(cmd) == 3:
+                pin, val = int(cmd[1]), int(cmd[2])
+                fpga.write_pin(pin, val)
+                print(f"Wrote Bit {pin} ({fpga.get_pin_name(pin)}) = {val}")
+            elif cmd[0] == "read" and len(cmd) == 2:
+                pin = int(cmd[1])
+                val = fpga.read_pin(pin)
+                print(f"Bit {pin} ({fpga.get_pin_name(pin)}) = {val}")
+            elif cmd[0] == "read_all":
+                val = fpga.read_all()
+                print(f"All bits = 0b{val:08b} (0x{val:02X})")
+                fpga.print_pin_map()
+            elif cmd[0] == "write_all" and len(cmd) == 2:
+                val = int(cmd[1], 0)
+                fpga.write_all(val)
+                print(f"Wrote all bits = 0x{val:02X}")
+            else:
+                print("Invalid command")
+        except Exception as e:
+            print(f"Error: {e}")
+
+
+# ===== MAIN MENU =====
+
+def main():
+    print("\n" + "="*60)
+    print("SHRIKE FPGA GPIO TESTER")
+    print("="*60)
+    print("\nFPGA Pin Mapping Reference:")
+    print("  Bit 0 -> GPIO07 (FPGA Pin 20)")
+    print("  Bit 1 -> GPIO08 (FPGA Pin 23)")
+    print("  Bit 2 -> GPIO09 (FPGA Pin 24)")
+    print("  Bit 3 -> GPIO10 (FPGA Pin 1)")
+    print("  Bit 4 -> GPIO11 (FPGA Pin 2)")
+    print("  Bit 5 -> GPIO12 (FPGA Pin 3)")
+    print("  Bit 6 -> GPIO13 (FPGA Pin 4)")
+    print("  Bit 7 -> GPIO14 (FPGA Pin 5)")
+    print("\n1. Run All Tests")
+    print("2. Test 1: Loopback")
+    print("3. Test 2: Individual Pins")
+    print("4. Test 3: Walking 1's")
+    print("5. Test 4: Bidirectional")
+    print("6. Test 5: Blink Pattern")
+    print("7. Interactive Mode")
+    print("8. Exit")
+    
+    while True:
+        try:
+            choice = input("\nSelect option (1-8): ").strip()
+            
+            if choice == "1":
+                run_all_tests()
+            elif choice == "2":
+                test_1_loopback()
+            elif choice == "3":
+                test_2_individual_pins()
+            elif choice == "4":
+                test_3_walking_ones()
+            elif choice == "5":
+                test_4_bidirectional()
+            elif choice == "6":
+                test_5_blink_pattern()
+            elif choice == "7":
+                interactive_mode()
+            elif choice == "8":
+                print("Goodbye!")
+                break
+            else:
+                print("Invalid choice")
+        except KeyboardInterrupt:
+            print("\n\nExiting...")
+            break
+
+if __name__ == "__main__":
+    main()

--- a/examples/8-Pin GPIO Extender/src/spi_target.v
+++ b/examples/8-Pin GPIO Extender/src/spi_target.v
@@ -1,0 +1,118 @@
+module spi_target #(
+  parameter CPOL   = 1'b0,  // When one, clock is low in idle, otherwise clock is high
+  parameter CPHA   = 1'b0,  // When one, sampling occurs at falling edge, otherwise at rising edge of non-inverted clock
+  parameter WIDTH  = 8,     // Determines the data width of SPI to the input and output data buses
+  parameter LSB    = 1'b0   // When one, data starts from LSB, otherwise data starts from MSB 
+) (
+// common ports
+  input                  i_clk,           // input clock signal
+  input                  i_rst_n,         // input negative reset signal
+// control signal
+  input                  i_enable,        // input enable SPI target signal
+// SPI interface ports
+  input                  i_ss_n,          // input target select signal
+  input                  i_sck,           // input spi clock signal
+  input                  i_mosi,          // input controller output target input signal
+  output                 o_miso,          // output controller input target output signal
+  output                 o_miso_oe,       // output miso enable output signal
+//RX internal ports
+  output reg [WIDTH-1:0] o_rx_data,       // output data bus
+  output reg             o_rx_data_valid, // output receive data valid signal
+//TX internal ports
+  input      [WIDTH-1:0] i_tx_data,       // input data bus
+  output                 o_tx_data_hold   // output signal used to get tx data from i_tx_data input
+);
+
+// Signal declaration
+  reg               [2:0] r_ss_n_sync, r_sck_sync;
+  reg [$clog2(WIDTH-1):0] r_transmision_count;
+  reg         [WIDTH-1:0] r_miso_data;
+  wire                    w_sck_r_edge, w_sck_f_edge, w_sck_edge, w_sck_edge_op;
+
+// SPI input signals synchronization
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      r_ss_n_sync <= 'b111;
+    end else if (i_enable) begin
+      r_ss_n_sync <= {r_ss_n_sync[1:0], i_ss_n};
+    end else begin
+      r_ss_n_sync <= 'b111;
+    end
+  end
+
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      r_sck_sync <= 'h0;
+    end else if (i_enable) begin
+      r_sck_sync <= {r_sck_sync[1:0], i_sck};
+    end else begin
+      r_sck_sync <= 'h0;
+    end
+  end
+
+// Create rising and falling edge signals from spi_clk signal
+  assign w_sck_r_edge  = ~r_sck_sync[2] & r_sck_sync[1];
+  assign w_sck_f_edge  = r_sck_sync[2] & ~r_sck_sync[1];
+  assign w_sck_edge    = (CPHA^CPOL) ? w_sck_f_edge : w_sck_r_edge;
+  assign w_sck_edge_op = (CPHA^CPOL) ? w_sck_r_edge : w_sck_f_edge;
+
+// Create transmission bit counter
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      r_transmision_count <= 'h0;
+    end else if (!i_enable || r_ss_n_sync[1]) begin
+      r_transmision_count <= 'h0;
+    end else if (w_sck_edge) begin
+      if (r_transmision_count == WIDTH-1) begin
+        r_transmision_count <= 'h0;
+      end else begin
+        r_transmision_count <= r_transmision_count + 1;
+      end
+    end
+  end
+
+// Create o_rx_data bus and valid signals
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      o_rx_data <= 'h0;
+    end else if (w_sck_edge) begin
+      if (LSB) begin
+        o_rx_data <= {i_mosi, o_rx_data[WIDTH-1:1]};
+      end else begin
+        o_rx_data <= {o_rx_data[WIDTH-2:0], i_mosi};
+      end
+    end
+  end
+
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      o_rx_data_valid <= 1'b0;
+    end else if (r_ss_n_sync[1] || (r_transmision_count == 0 && w_sck_edge)) begin
+      o_rx_data_valid <= 1'b0;
+    end else if (w_sck_edge && r_transmision_count == WIDTH-1) begin
+      o_rx_data_valid <= 1'b1;
+    end
+  end
+
+// Create o_tx_data_hold signal
+  assign o_tx_data_hold = (~CPHA & r_ss_n_sync[2] & ~r_ss_n_sync[1]) | (r_transmision_count == 0 & w_sck_edge_op);
+
+// Create o_miso and OE signals
+  always @(posedge i_clk or negedge i_rst_n) begin
+    if (!i_rst_n) begin
+      r_miso_data <= 'h0;
+    end else if (o_tx_data_hold) begin
+      r_miso_data <= i_tx_data;
+    end else if (w_sck_edge_op) begin
+      if (LSB) begin
+        r_miso_data <= r_miso_data >> 1;
+      end else begin
+        r_miso_data <= r_miso_data << 1;
+      end
+    end
+  end
+
+  assign o_miso    = (LSB) ? r_miso_data[0] : r_miso_data[WIDTH-1];
+  assign o_miso_oe = ~r_ss_n_sync[2];
+
+endmodule

--- a/examples/8-Pin GPIO Extender/src/top.v
+++ b/examples/8-Pin GPIO Extender/src/top.v
@@ -1,0 +1,79 @@
+(* top *) module top (
+    (* iopad_external_pin, clkbuf_inhibit *) input clk,
+    (* iopad_external_pin *) output clk_en,
+    (* iopad_external_pin *) input rst_n,
+
+    
+    (* iopad_external_pin *) input spi_ss_n,   
+    (* iopad_external_pin *) input spi_sck,    
+    (* iopad_external_pin *) input spi_mosi,   
+    (* iopad_external_pin *) output spi_miso,  
+    (* iopad_external_pin *) output spi_miso_en,
+
+    // 8-bit GPIO Interface
+    (* iopad_external_pin *) input  [7:0] i_gpio_pins,
+    (* iopad_external_pin *) output [7:0] o_gpio_pins,
+    (* iopad_external_pin *) output [7:0] o_gpio_en
+);
+
+    
+    assign clk_en = 1'b1;
+
+    // Wires for SPI Module
+    wire [7:0] spi_rx_data;
+    wire spi_rx_valid;
+    wire [7:0] spi_tx_data;
+
+    // Instantiate SPI Target
+    spi_target #( .WIDTH(8) ) u_spi_target (
+        .i_clk(clk),
+        .i_rst_n(rst_n),
+        .i_enable(1'b1),
+        .i_ss_n(spi_ss_n),
+        .i_sck(spi_sck),
+        .i_mosi(spi_mosi),
+        .o_miso(spi_miso),
+        .o_miso_oe(spi_miso_en),
+        .o_rx_data(spi_rx_data),
+        .o_rx_data_valid(spi_rx_valid),
+        .i_tx_data(spi_tx_data),
+        .o_tx_data_hold()
+    );
+
+    // GPIO Control Registers
+    reg [7:0] gpio_dir_reg; // 1'b0 = Output, 1'b1 = Input
+    reg [7:0] gpio_out_reg; // Data to be driven to pins
+
+    // Logic to handle SPI Commands
+    reg spi_rx_valid_d;
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            spi_rx_valid_d <= 1'b0;
+            gpio_dir_reg   <= 8'hFF; // Default to all Inputs
+            gpio_out_reg   <= 8'h00;
+        end else begin
+            spi_rx_valid_d <= spi_rx_valid;
+
+            // Detect rising edge of spi_rx_valid
+            if (spi_rx_valid && !spi_rx_valid_d) begin
+                // Simple Command Protocol: {Addr[3:0], Data[3:0]}
+                // This allows updating nibbles (4-bits) of the 8-bit registers
+                case (spi_rx_data[7:4])
+                    4'h1: gpio_dir_reg[3:0] <= spi_rx_data[3:0]; // Set lower nibble dir
+                    4'h2: gpio_dir_reg[7:4] <= spi_rx_data[3:0]; // Set upper nibble dir
+                    4'h3: gpio_out_reg[3:0] <= spi_rx_data[3:0]; // Set lower nibble data
+                    4'h4: gpio_out_reg[7:4] <= spi_rx_data[3:0]; // Set upper nibble data
+                endcase
+            end
+        end
+    end
+    
+    // Readback: Always reflects the physical state of the 8 GPIO pins
+    assign spi_tx_data = i_gpio_pins;
+
+    // GPIO Output Assignments
+    assign o_gpio_pins = gpio_out_reg;
+    assign o_gpio_en   = ~gpio_dir_reg; // OE is high when DIR is Output (0)
+
+endmodule


### PR DESCRIPTION
The 8-pin GPIO Extender
This project implements a custom "Soft-Peripheral" on the Vicharak Shrike Lite board. By leveraging the FPGA, the design provides the RP2040 with 8 additional independent GPIOs, bypassing the physical pin limitations of the MCU.

Technical Implementation:

SPI Protocol: Uses a custom address/data nibble structure ({Addr[3:0], Data[3:0]}) to manage direction and data registers.

Hardware Logic: Implements manual Output Enable (OE) management for the Renesas ForgeFPGA, allowing for true tristate bi-directional control.

Simultaneous I/O: The FPGA shifts out the current physical state of all pins during every SPI write, enabling low-latency polling.

Included in this PR:
Verilog source files (top.v, spi_target.v).
Register map and pin-mapping documentation.


The 14-pin GPIO Extender
Implement Verilog RTL for 14-bit bidirectional GPIO controller
- Add SPI slave module with 2-byte command protocol
- Create MicroPython driver with full test coverage
- Include beginner-friendly examples and documentation
- Optimize for minimal FPGA resource usage (11.4% CLB)

Tested on Vicharak Shrike Lite with RP2040 only.
All hardware tests passed successfully.