### PR TITLE
fix :  shrike_fpga message , docs : CAPITALISE the doc name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,7 @@ Build the bitstream in GCSH, copy the output `.bin` file into `bitstream/`, and 
 
 If your example includes MCU firmware, write it to support all Shrike boards from a single source file using compile-time (`#ifdef`) or runtime (`sys.platform`) detection.
 
-See the [Platform-Agnostic Firmware Guide](docs/platform_agnostic_guide.md) for patterns and examples.
+See the [Platform-Agnostic Firmware Guide](docs/PLATFORM_AGNOSTIC_FIRMWARE_GUIDE.md) for patterns and examples.
 
 ### Naming Conventions
 

--- a/archive/shrike_micropy/shrike_fpga.py
+++ b/archive/shrike_micropy/shrike_fpga.py
@@ -55,14 +55,15 @@ def flash(filename: str, word_size=46408):
                 if not word:
                     break
                 SPI.write(word)
+    
+        SS.value(1)
+        utime.sleep(0.1)
+        print("[shrike_flash] FPGA programming done.")
     except OSError as e:
         print(f"[shrike_flash] File error: {e}")
     except Exception as e:
         print(f"[shrike_flash] Error: {e}")
 
-    SS.value(1)
-    utime.sleep(0.1)
-    print("[shrike_flash] FPGA programming done.")
     
 def reset():
     """


### PR DESCRIPTION
## What does this PR do?

<!-- Describe your changes in 1-3 sentences. -->
-  Fixes 1,3 of #55 

## Type of change

- [ ] New example
- [x] Bug fix
- [ ] Documentation update
- [ ] Firmware improvement
- [ ] Tooling / CI
- [ ] Other

## Board(s) tested on

- [x] Shrike-Lite (RP2040)
- [ ] Shrike (RP2350)
- [ ] Shrike-fi (ESP32-S3)
- [ ] Not hardware-dependent

## Checklist

### For all PRs:
- [x] I have tested my changes
- [ ] My code follows the project's style guidelines
- [ ] I have updated relevant documentation (if applicable)

### For new examples:
- [ ] Follows the [standard folder structure](CONTRIBUTING.md#folder-structure) (`ffpga/`, `firmware/`, `bitstream/`, `README.md`)
- [ ] Includes pre-built bitstream in `bitstream/`
- [ ] Includes README with difficulty level, compatibility table, and expected output
- [ ] Firmware is platform-agnostic (`#ifdef` / `sys.platform`) — see [guide](docs/platform_agnostic_guide.md)
- [ ] Tested with ShrikeFlash

### For firmware changes:
- [ ] Works on RP2040
- [ ] Works on ESP32-S3 (or marked as untested in README)
- [ ] No hardcoded pin numbers (uses platform config block)

## Related issue

<!-- Link to the issue this fixes, e.g., Fixes #42. Leave blank if none. -->


## Screenshots / serial output

<!-- If applicable, paste evidence that it works. -->
