### PR TITLE
example : port spi_loopback example for shrike-fi

### DIFF
--- a/examples/spi_loopback_led/firmware/micropython/spi_loopback_led.py
+++ b/examples/spi_loopback_led/firmware/micropython/spi_loopback_led.py
@@ -1,33 +1,54 @@
+import sys
+import shrike
 from machine import Pin, SPI
 import time
 
-# Reset
+
+#Flash the bitstream into the FPGA ic
+shrike.flash("spi_loopback_led.bin")
+
+# --- 1. Platform-Specific Pin Routing ---
+if sys.platform == 'rp2':
+    # Shrike Lite (RP2040)
+    SPI_ID = 0
+    SCK_PIN = 2
+    MOSI_PIN = 3
+    MISO_PIN = 0
+    CS_PIN = 1
+
+elif sys.platform == 'esp32':
+    # Shrike FI (ESP32)
+    SPI_ID = 2
+    SCK_PIN = 12
+    MOSI_PIN = 11
+    MISO_PIN = 13
+    CS_PIN = 10
+
+else:
+    raise RuntimeError("Unsupported platform!")
+
+# --- 2. Shared Hardware Reset ---
+# Both platforms use Pin 14 for reset in this loopback test
 reset_pin = Pin(14, Pin.OUT, value=1)
 reset_pin.value(0)
 time.sleep(1)
 reset_pin.value(1)
 time.sleep(1)
 
-# RP2040
-SCK  = 2  
-CS   = 1  
-MOSI = 3  
-MISO = 0  
+# --- 3. Shared SPI Initialization ---
+cs = Pin(CS_PIN, Pin.OUT, value=1)
 
-# Chip Select pin
-cs = Pin(CS, Pin.OUT, value=1)
-
-# SPI configuration (MODE 0, MSB first)
-spi = SPI(0,
+spi = SPI(SPI_ID,
           baudrate=1_000_000,
           polarity=0,
           phase=0,
           bits=8,
           firstbit=SPI.MSB,
-          sck=Pin(SCK),
-          mosi=Pin(MOSI),
-          miso=Pin(MISO))
+          sck=Pin(SCK_PIN),
+          mosi=Pin(MOSI_PIN),
+          miso=Pin(MISO_PIN))
 
+# --- 4. Loopback Function ---
 def spi_exchange(byte_to_send):
     tx = bytes([byte_to_send])
     rx = bytearray(1)
@@ -38,6 +59,8 @@ def spi_exchange(byte_to_send):
 
     return rx[0]
 
+# --- 5. Main Execution Loop ---
+print(f"Starting SPI Loopback on {sys.platform}...")
 
 while True:
     for val in [0xAB, 0xFF]:


### PR DESCRIPTION
Added comments for Shrike Fi (ESP32 - S3) SPI configuration. Changes in Pin assignments and SPI mode to make the code work on Shrike Fi board

## What does this PR do?

<!-- Describe your changes in 1-3 sentences. -->


## Type of change

- [ ] New example
- [ ] Bug fix
- [ ] Documentation update
- [x] Firmware improvement
- [ ] Tooling / CI
- [x] Other

## Board(s) tested on

- [x] Shrike-Lite (RP2040)
- [x] Shrike (RP2350)
- [x] Shrike-fi (ESP32-S3)
- [x] Not hardware-dependent

## Checklist

### For all PRs:
- [x] I have tested my changes
- [x] My code follows the project's style guidelines
- [x] I have updated relevant documentation (if applicable)

### For new examples:
- [ ] Follows the [standard folder structure](CONTRIBUTING.md#folder-structure) (`ffpga/`, `firmware/`, `bitstream/`, `README.md`)
- [ ] Includes pre-built bitstream in `bitstream/`
- [ ] Includes README with difficulty level, compatibility table, and expected output
- [ ] Firmware is platform-agnostic (`#ifdef` / `sys.platform`) — see [guide](docs/platform_agnostic_guide.md)
- [ ] Tested with ShrikeFlash

### For firmware changes:
- [x] Works on RP2040
- [x] Works on ESP32-S3 (or marked as untested in README)
- [ ] No hardcoded pin numbers (uses platform config block)

## Related issue

<!-- Link to the issue this fixes, e.g., Fixes #42. Leave blank if none. -->


## Screenshots / serial output

<!-- If applicable, paste evidence that it works. -->
