### PR TITLE
To test whether the PSRAM is being detected in the Shrike-Fi.

### DIFF
--- a/examples/PSRAM_test/PSRAM_test.ino
+++ b/examples/PSRAM_test/PSRAM_test.ino
@@ -1,0 +1,21 @@
+/*  This code checks for the presence of PSRAM and prints its size. */
+
+void setup()
+{
+    Serial.begin(115200);
+
+    if (psramFound()) {
+        Serial.printf("PSRAM Found\n");
+    } 
+    else {
+        Serial.println("PSRAM NOT Found");
+        return;
+    }
+
+   //Check the total size of PSRAM
+    Serial.printf("Size of PSRAM: %d bytes \n", ESP.getPsramSize());    
+}
+
+void loop()
+{
+}

--- a/examples/PSRAM_test/README.md
+++ b/examples/PSRAM_test/README.md
@@ -17,7 +17,7 @@ This project verifies whether the PSRAM is being detected in the Shrike-Fi board
 1. Open `PSRAM_test.ino`.
 2. In the Tools menu, select ESP32S3 Dev Module as the board [**Tools > Board**].
 3. In the Tools menu, select the port to which the Shrike-Fi is connected [**Tools > Port**].
-4. In the Tools menu, if PSRAM is disabled by default. Click on **PSRAM and select QSPI PSRAM**[**Tools > PSRAM**].
+4. In the Tools menu, if PSRAM is disabled by default. Click on **PSRAM and select QSPI PSRAM** [**Tools > PSRAM**].
 5. Upload the sketch.
 
 ## How to Run

--- a/examples/PSRAM_test/README.md
+++ b/examples/PSRAM_test/README.md
@@ -1,0 +1,44 @@
+# PSRAM Test (Shrike fi)
+
+This project verifies whether the PSRAM is being detected in the Shrike-Fi board.
+
+## What `PSRAM_test.ino` does
+
+1. Starts serial communication at `115200` baud.
+2. Checks PSRAM availability using `psramFound()`.
+3. Prints total PSRAM size using `ESP.getPsramSize()`.
+
+## Requirements
+
+- Arduino IDE
+- ESP32 board package installed
+## Arduino IDE Setup
+
+1. Open `PSRAM_test.ino`.
+2. In the Tools menu, select ESP32S3 Dev Module as the board [**Tools > Board**].
+3. In the Tools menu, select the port to which the Shrike-Fi is connected [**Tools > Port**].
+4. In the Tools menu, if PSRAM is disabled by default. Click on **PSRAM and select QSPI PSRAM**[**Tools > PSRAM**].
+5. Upload the sketch.
+
+## How to Run
+
+1. Open **Serial Monitor**.
+2. Set baud rate to **115200**.
+3. Press reset.
+4. Check the printed output.
+
+## Expected Output
+
+If PSRAM is available:
+
+```text
+PSRAM Found
+Size of PSRAM: <number> bytes
+```
+
+If PSRAM is not available:
+
+```text
+PSRAM NOT Found
+```
+


### PR DESCRIPTION
## This is a new example for testing PSRAM on the Shrike-Fi board.

Example Path: shrike/examples/PSRAM_test

Verifies whether PSRAM is detected
Prints the total PSRAM size in bytes
Tested on Shrike-Fi (ESP32-S3) board