### PR TITLE
Fix shrike-ctl.py uploading only the last firmware file when multiple paths are given

### DIFF
--- a/utils/shrike-ctl/shrike-ctl.py
+++ b/utils/shrike-ctl/shrike-ctl.py
@@ -13,38 +13,38 @@ BAUDRATE = 115200  # Match Shrike Baud Rate
 CHUNK_SIZE = 46408 # Size of Bitstream
 
 if len(sys.argv) > 2:
-    file_paths = sys.argv[2:]
-else:
-    FILE_PATH = input("Enter firmware file path : ").strip()
-    file_paths = [FILE_PATH]
-
-for FILE_PATH in file_paths:
-    if not os.path.exists(FILE_PATH):
-        print(f" Error: File not found: {FILE_PATH}")
-        continue
-    if os.path.isdir(FILE_PATH):
-        print(f" Error: '{FILE_PATH}' is a DIRECTORY!")
-        continue
-    if not os.path.isfile(FILE_PATH):
-        print(f" Error: '{FILE_PATH}' is not a file")
-        continue
-    
-file_size = os.path.getsize(FILE_PATH)
-print(f" Uploading: {os.path.basename(FILE_PATH)} ({file_size} bytes)")
-
-ser = serial.Serial(PORT, BAUDRATE, timeout=1, rtscts=False, dsrdtr=False)
-file_size = os.path.getsize(FILE_PATH)
-print(f"File size: {file_size} bytes")
-sent = 0
-with open(FILE_PATH, "rb") as file:
-    while sent < file_size:
-        data = file.read(CHUNK_SIZE)
-        if not data:
-              break
-        ser.write(data)
-        sent += len(data)
-        print(f"Sent {sent}/{file_size} bytes", end='\r')
-        time.sleep(0.01)  # 10ms delay
-
-print(f"\nFile transfer complete. Total: {sent} bytes")
-ser.close()
+    16	    file_paths = sys.argv[2:]
+17	else:
+18	    FILE_PATH = input("Enter firmware file path : ").strip()
+19	    file_paths = [FILE_PATH]
+20	
+21	ser = serial.Serial(PORT, BAUDRATE, timeout=1, rtscts=False, dsrdtr=False)
+22	
+23	for FILE_PATH in file_paths:
+24	    if not os.path.exists(FILE_PATH):
+25	        print(f" Error: File not found: {FILE_PATH}")
+26	        continue
+27	    if os.path.isdir(FILE_PATH):
+28	        print(f" Error: '{FILE_PATH}' is a DIRECTORY!")
+29	        continue
+30	    if not os.path.isfile(FILE_PATH):
+31	        print(f" Error: '{FILE_PATH}' is not a file")
+32	        continue
+33	
+34	    file_size = os.path.getsize(FILE_PATH)
+35	    print(f" Uploading: {os.path.basename(FILE_PATH)} ({file_size} bytes)")
+36	
+37	    sent = 0
+38	    with open(FILE_PATH, "rb") as file:
+39	        while sent < file_size:
+40	            data = file.read(CHUNK_SIZE)
+41	            if not data:
+42	                break
+43	            ser.write(data)
+44	            sent += len(data)
+45	            print(f"Sent {sent}/{file_size} bytes", end='\r')
+46	            time.sleep(0.01)  # 10ms delay
+47	
+48	    print(f"\nFile transfer complete. Total: {sent} bytes")
+49	
+50	ser.close()

--- a/utils/shrike-ctl/shrike-ctl.py
+++ b/utils/shrike-ctl/shrike-ctl.py
@@ -13,38 +13,38 @@ BAUDRATE = 115200  # Match Shrike Baud Rate
 CHUNK_SIZE = 46408 # Size of Bitstream
 
 if len(sys.argv) > 2:
-    16	    file_paths = sys.argv[2:]
-17	else:
-18	    FILE_PATH = input("Enter firmware file path : ").strip()
-19	    file_paths = [FILE_PATH]
-20	
-21	ser = serial.Serial(PORT, BAUDRATE, timeout=1, rtscts=False, dsrdtr=False)
-22	
-23	for FILE_PATH in file_paths:
-24	    if not os.path.exists(FILE_PATH):
-25	        print(f" Error: File not found: {FILE_PATH}")
-26	        continue
-27	    if os.path.isdir(FILE_PATH):
-28	        print(f" Error: '{FILE_PATH}' is a DIRECTORY!")
-29	        continue
-30	    if not os.path.isfile(FILE_PATH):
-31	        print(f" Error: '{FILE_PATH}' is not a file")
-32	        continue
-33	
-34	    file_size = os.path.getsize(FILE_PATH)
-35	    print(f" Uploading: {os.path.basename(FILE_PATH)} ({file_size} bytes)")
-36	
-37	    sent = 0
-38	    with open(FILE_PATH, "rb") as file:
-39	        while sent < file_size:
-40	            data = file.read(CHUNK_SIZE)
-41	            if not data:
-42	                break
-43	            ser.write(data)
-44	            sent += len(data)
-45	            print(f"Sent {sent}/{file_size} bytes", end='\r')
-46	            time.sleep(0.01)  # 10ms delay
-47	
-48	    print(f"\nFile transfer complete. Total: {sent} bytes")
-49	
-50	ser.close()
+    file_paths = sys.argv[2:]
+else:
+    FILE_PATH = input("Enter firmware file path : ").strip()
+    file_paths = [FILE_PATH]
+
+ser = serial.Serial(PORT, BAUDRATE, timeout=1, rtscts=False, dsrdtr=False)
+
+for FILE_PATH in file_paths:
+    if not os.path.exists(FILE_PATH):
+        print(f" Error: File not found: {FILE_PATH}")
+        continue
+    if os.path.isdir(FILE_PATH):
+        print(f" Error: '{FILE_PATH}' is a DIRECTORY!")
+        continue
+    if not os.path.isfile(FILE_PATH):
+        print(f" Error: '{FILE_PATH}' is not a file")
+        continue
+
+    file_size = os.path.getsize(FILE_PATH)
+    print(f" Uploading: {os.path.basename(FILE_PATH)} ({file_size} bytes)")
+
+    sent = 0
+    with open(FILE_PATH, "rb") as file:
+        while sent < file_size:
+            data = file.read(CHUNK_SIZE)
+            if not data:
+                break
+            ser.write(data)
+            sent += len(data)
+            print(f"Sent {sent}/{file_size} bytes", end='\r')
+            time.sleep(0.01)  # 10ms delay
+
+    print(f"\nFile transfer complete. Total: {sent} bytes")
+
+ser.close()

--- a/utils/shrike-ctl/test_shrike_ctl.py
+++ b/utils/shrike-ctl/test_shrike_ctl.py
@@ -1,0 +1,63 @@
+"""
+Regression test for shrike-ctl.py.
+
+shrike-ctl.py accepts one or more firmware/bitstream paths on the command
+line (`sys.argv[2:]`) and validates each one inside a loop. The upload
+itself must happen for every validated path, not just the last one.
+
+This test stubs out `serial.Serial` so no hardware is required, runs the
+real script with two fake bitstream files on argv, and checks that the
+bytes of *both* files were written to the serial port.
+"""
+
+import os
+import runpy
+import sys
+import types
+
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), "shrike-ctl.py")
+
+
+class FakeSerial:
+    """Stand-in for serial.Serial that records every write() call."""
+
+    instances = []
+
+    def __init__(self, port, baudrate, timeout=1, rtscts=False, dsrdtr=False):
+        self.port = port
+        self.writes = []
+        FakeSerial.instances.append(self)
+
+    def write(self, data):
+        self.writes.append(bytes(data))
+
+    def close(self):
+        pass
+
+
+def run_script_with_files(file_paths, monkeypatch):
+    """Run shrike-ctl.py as if invoked from the CLI with file_paths,
+    capturing everything written to the fake serial port."""
+    FakeSerial.instances.clear()
+
+    fake_serial_module = types.ModuleType("serial")
+    fake_serial_module.Serial = FakeSerial
+    monkeypatch.setitem(sys.modules, "serial", fake_serial_module)
+    monkeypatch.setattr(sys, "argv", ["shrike-ctl.py", "/dev/ttyFAKE", *file_paths])
+
+    runpy.run_path(SCRIPT_PATH, run_name="__main__")
+
+    assert FakeSerial.instances, "script never opened the serial port"
+    return b"".join(b"".join(inst.writes) for inst in FakeSerial.instances)
+
+
+def test_uploads_every_file_passed_on_the_command_line(monkeypatch, tmp_path):
+    first = tmp_path / "first.bin"
+    second = tmp_path / "second.bin"
+    first.write_bytes(b"A" * 10)
+    second.write_bytes(b"B" * 10)
+
+    written = run_script_with_files([str(first), str(second)], monkeypatch)
+
+    assert b"A" * 10 in written, "bytes of the first firmware file were never sent over serial"
+    assert b"B" * 10 in written, "bytes of the second firmware file were never sent over serial"


### PR DESCRIPTION
## What does this PR do?
`shrike-ctl.py` accepts multiple firmware paths on the CLI (`sys.argv[2:]`) and validates each one in a loop, but the actual serial-open/read/write block was dedented outside that loop — so only the last file ever got uploaded while earlier files were silently dropped with no error. This moves the upload logic back inside the loop so every validated file is sent.

## Type of change
- [ ] New example
- [x] Bug fix
- [ ] Documentation update
- [ ] Firmware improvement
- [ ] Tooling / CI
- [ ] Other

## Board(s) tested on
- [ ] Shrike-Lite (RP2040)
- [ ] Shrike (RP2350)
- [ ] Shrike-fi (ESP32-S3)
- [x] Not hardware-dependent

## Checklist
### For all PRs:
- [x] I have tested my changes
- [x] My code follows the project's style guidelines
- [ ] I have updated relevant documentation (if applicable)

### For new examples:
N/A — not a new example.

### For firmware changes:
N/A — this is a host-side Python script, not firmware.

## Related issue
None.

## Screenshots / serial output
Added `utils/shrike-ctl/test_shrike_ctl.py`, which stubs `serial.Serial` and runs the real script against two fake firmware files:
- Against the unmodified script: `AssertionError: bytes of the first firmware file were never sent over serial` (only the second file's bytes show up).
- Against the fixed script: test passes, both files' bytes are written to the serial port.