### PR TITLE
Fix shrike-ctl.py uploading only the last file in multi-file mode

### DIFF
--- a/test/shrike_ctl_multi_file_test.py
+++ b/test/shrike_ctl_multi_file_test.py
@@ -1,0 +1,79 @@
+"""
+Regression test for utils/shrike-ctl/shrike-ctl.py.
+
+The repo has no existing Python test framework (test/blink_test.py and friends
+are MicroPython scripts meant to run on real hardware, not assertion-based
+unit tests), so this uses the standard-library `unittest` module and avoids
+any hardware or third-party (pyserial) dependency by stubbing out the
+`serial` module before the script is executed.
+
+Behavior under test: when shrike-ctl.py is given multiple bitstream files on
+the command line, every file must be sent over the serial port -- not just
+the last one.
+"""
+import os
+import runpy
+import sys
+import tempfile
+import types
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPT_PATH = os.path.join(REPO_ROOT, "utils", "shrike-ctl", "shrike-ctl.py")
+
+
+class FakeSerial:
+    """Stand-in for serial.Serial that records every write() call."""
+
+    def __init__(self, port, baudrate, timeout=1, rtscts=False, dsrdtr=False):
+        self.port = port
+        self.baudrate = baudrate
+
+    def write(self, data):
+        FakeSerial.writes.append(bytes(data))
+        return len(data)
+
+    def close(self):
+        pass
+
+
+class ShrikeCtlMultiFileTest(unittest.TestCase):
+    def setUp(self):
+        # Stub the `serial` module so the script can run without pyserial
+        # or a real device attached.
+        FakeSerial.writes = []
+        self._real_serial_module = sys.modules.get("serial")
+        fake_serial_module = types.ModuleType("serial")
+        fake_serial_module.Serial = FakeSerial
+        sys.modules["serial"] = fake_serial_module
+
+        self._real_argv = sys.argv
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        if self._real_serial_module is not None:
+            sys.modules["serial"] = self._real_serial_module
+        else:
+            sys.modules.pop("serial", None)
+        sys.argv = self._real_argv
+        self.tmpdir.cleanup()
+
+    def test_all_files_are_uploaded_not_just_the_last(self):
+        first_path = os.path.join(self.tmpdir.name, "first.bin")
+        second_path = os.path.join(self.tmpdir.name, "second.bin")
+        with open(first_path, "wb") as f:
+            f.write(b"AAAA")
+        with open(second_path, "wb") as f:
+            f.write(b"BBBB")
+
+        sys.argv = ["shrike-ctl.py", "/dev/ttyFAKE", first_path, second_path]
+
+        runpy.run_path(SCRIPT_PATH, run_name="__main__")
+
+        sent_data = b"".join(FakeSerial.writes)
+        self.assertIn(b"AAAA", sent_data, "first file was never sent")
+        self.assertIn(b"BBBB", sent_data, "second file was never sent")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/shrike-ctl/shrike-ctl.py
+++ b/utils/shrike-ctl/shrike-ctl.py
@@ -18,6 +18,8 @@ else:
     FILE_PATH = input("Enter firmware file path : ").strip()
     file_paths = [FILE_PATH]
 
+ser = serial.Serial(PORT, BAUDRATE, timeout=1, rtscts=False, dsrdtr=False)
+
 for FILE_PATH in file_paths:
     if not os.path.exists(FILE_PATH):
         print(f" Error: File not found: {FILE_PATH}")
@@ -28,23 +30,21 @@ for FILE_PATH in file_paths:
     if not os.path.isfile(FILE_PATH):
         print(f" Error: '{FILE_PATH}' is not a file")
         continue
-    
-file_size = os.path.getsize(FILE_PATH)
-print(f" Uploading: {os.path.basename(FILE_PATH)} ({file_size} bytes)")
 
-ser = serial.Serial(PORT, BAUDRATE, timeout=1, rtscts=False, dsrdtr=False)
-file_size = os.path.getsize(FILE_PATH)
-print(f"File size: {file_size} bytes")
-sent = 0
-with open(FILE_PATH, "rb") as file:
-    while sent < file_size:
-        data = file.read(CHUNK_SIZE)
-        if not data:
-              break
-        ser.write(data)
-        sent += len(data)
-        print(f"Sent {sent}/{file_size} bytes", end='\r')
-        time.sleep(0.01)  # 10ms delay
+    file_size = os.path.getsize(FILE_PATH)
+    print(f" Uploading: {os.path.basename(FILE_PATH)} ({file_size} bytes)")
 
-print(f"\nFile transfer complete. Total: {sent} bytes")
+    sent = 0
+    with open(FILE_PATH, "rb") as file:
+        while sent < file_size:
+            data = file.read(CHUNK_SIZE)
+            if not data:
+                break
+            ser.write(data)
+            sent += len(data)
+            print(f"Sent {sent}/{file_size} bytes", end='\r')
+            time.sleep(0.01)  # 10ms delay
+
+    print(f"\nFile transfer complete. Total: {sent} bytes")
+
 ser.close()


### PR DESCRIPTION
## What does this PR do?
Fixes a bug in `shrike-ctl.py` where the file-transfer logic sat outside the `for FILE_PATH in file_paths:` loop, so passing multiple bitstream files on the command line silently uploaded only the last one. The transfer logic is now inside the loop so every file gets sent. Adds a regression test.

## Type of change
- [ ] New example
- [x] Bug fix
- [ ] Documentation update
- [ ] Firmware improvement
- [ ] Tooling / CI
- [ ] Other

## Board(s) tested on
- [ ] Shrike-Lite (RP2040)
- [ ] Shrike (RP2350)
- [ ] Shrike-fi (ESP32-S3)
- [x] Not hardware-dependent

## Checklist
### For all PRs:
- [x] I have tested my changes
- [x] My code follows the project's style guidelines
- [ ] I have updated relevant documentation (if applicable)

### For new examples:
- [ ] Follows the standard folder structure (`ffpga/`, `firmware/`, `bitstream/`, `README.md`)
- [ ] Includes pre-built bitstream in `bitstream/`
- [ ] Includes README with difficulty level, compatibility table, and expected output
- [ ] Firmware is platform-agnostic (`#ifdef` / `sys.platform`)
- [ ] Tested with ShrikeFlash

### For firmware changes:
- [ ] Works on RP2040
- [ ] Works on ESP32-S3 (or marked as untested in README)
- [ ] No hardcoded pin numbers (uses platform config block)

## Related issue
None.

## Screenshots / serial output
Verified with a stubbed serial connection (no hardware needed): before the fix, passing two files only sent the second file's bytes. After the fix, both files' bytes are sent in order. Covered by `test/shrike_ctl_multi_file_test.py`.